### PR TITLE
API cleanup

### DIFF
--- a/docs/api-account.md
+++ b/docs/api-account.md
@@ -5,127 +5,46 @@ sidebar_label: Account API
 todo: Modify links to old API docs
 ---
 
-<div id="docBody">
-<p>The Account API returns information on a token's call volume and billing history.</p>
+The Account API returns information on a token's call volume and billing history.
 
-<h3 id="request">Request</h3>
-<div class="indent">
-<p>To use the Account API, perform a HTTP GET request on the following endpoint:</p>
-  
+## Request
 
-```text
+To use the Account API, perform a HTTP GET request on the following endpoint:
+
+```plaintext
 https://api.diffbot.com/v3/account
 ```
 
+Provide the following arguments:
 
-<p>Provide the following arguments:</p>
-<table class="controls table table-bordered" border="0" cellpadding="5">
-<thead><tr>
-<th>Argument</th>
-<th>Description</th>
-</tr></thead>
-<tbody>
-<tr>
-<td><code>token</code></td>
-<td>Developer <a href="https://diffbot.com/pricing">token</a>
-</td>
-</tr>
-<tr><td colspan="2"><strong>Optional parameters</strong></td></tr>
-<tr class="opt">
-<td><code>days</code></td>
-<td>Pass the number of days (<code>&amp;days=365</code>) for which you would like to retrieve API call volumes (default = 31).</td>
-</tr>
-<tr class="opt">
-<td><code>invoices</code></td>
-<td>Pass <code>&amp;invoices=true</code> to return invoice and payment history.</td>
-</tr>
-</tbody>
-</table>
-<h3 id="response">Response</h3>
-<p>The Account API returns account details in JSON format. Items returned will include the following:</p>
+| Argument | Description |
+| :------- | :---------- |
+| `token` | Developer [token](https://www.diffbot.com/pricing) </td></tr><td colspan="2">**Optional arguments**</td> |
+| `days` | Pass the number of days (`&days=365`) for which you would like to retrieve API call volumes (default = 31). |
+| `invoices` | Pass `&invoices=true` to return invoice and payment history. |
 
-<table class="controls table table-bordered" id="fields" border="0" cellpadding="5">
-<thead><tr>
-<th>Field</th>
-<th>Description</th>
-</tr></thead>
-<tr>
-<td class=""><code>name</code></td>
-<td class=" default"><div>Name associated with the token.</div></td>
-</tr>
-<tr>
-<td class=""><code>email</code></td>
-<td class=" default"><div>Email address associated with the token.</div></td>
-</tr>
-<tr>
-<td class=""><code>plan</code></td>
-<td class=" default"><div>Current plan for the token.</div></td>
-</tr>
-<tr>
-<td class=""><code>planCalls</code></td>
-<td class=" default"><div>Amount of monthly calls included.</div></td>
-</tr>
-<tr>
-<td class=""><code>status</code></td>
-<td class=" default"><div>Status of the token.</div></td>
-</tr>
-<tr>
-<td><code>childTokens</code></td>
-<td><div>List of child or sub-tokens, if there are any associated with your account.</div></td>
-</tr>
-<tr>
-<td class="parent"><code>apiCalls</code></td>
-<td class="parent default"><div>An array of days and call volume amounts for each day. By default this will return data from the most recent 31 days. Use the <code>days</code> argument to adjust the response window. Dates prior to token becoming active will not be returned.</div></td>
-</tr>
-<tr>
-<td class="indent"><code>date</code></td>
-<td class="indent"><div>Date, e.g. <code>2015-10-01</code>.</div></td>
-</tr>
-<tr>
-<td class="indent"><code>calls</code></td>
-<td class="indent"><div>Total number of API calls made.</div></td>
-</tr>
-<tr>
-<td class="indent"><code>proxyCalls</code></td>
-<td class="indent"><div>Total number of calls made using proxy servers. <a href="explain-using-different-proxies">Read more</a>.</div></td>
-</tr>
-<tr>
-<td class="indent"><code>giCalls</code></td>
-<td class="indent"><div>Total number of search calls made against the <a href="/dev/docs/global-index">Global Index</a>.</div></td>
-</tr>
-<tr>
-<td class="parent"><code>invoices</code></td>
-<td class="parent default"><div>Array of invoices for paid accounts.</div></td>
-</tr>
-<tr>
-<td class="indent"><code>date</code></td>
-<td class="indent"><div>Date of invoice.</div></td>
-</tr>
-<tr>
-<td class="indent"><code>periodStart</code></td>
-<td class="indent"><div>Billing period start date (resolved to day).</div></td>
-</tr>
-<tr>
-<td class="indent"><code>periodEnd</code></td>
-<td class="indent"><div>Billing period end date (resolved to day).</div></td>
-</tr>
-<tr>
-<td class="indent"><code>totalCalls</code></td>
-<td class="indent"><div>Total calls made during the billing period.</div></td>
-</tr>
-<tr>
-<td class="indent"><code>totalAmount</code></td>
-<td class="indent"><div>Total amount charged.</div></td>
-</tr>
-<tr>
-<td class="indent"><code>overageAmount</code></td>
-<td class="indent"><div>Total overage amount billed if call volume exceeded included number of monthly calls.</div></td>
-</tr>
-<tr>
-<td class="indent"><code>status</code></td>
-<td class="indent"><div>Payment status of invoice (<code>paid</code> or <code>unpaid</code>).</div></td>
-</tr>
-</table>
+## Response
 
-</div>
-</div>
+The Account API returns account details in JSON format. Items returned will include the following:
+
+| Field | Description |
+| :---- | :---------- |
+| `name` | Name associated with the token. |
+| `email` | Email address associated with the token. |
+| `plan` | Current plan for the token. |
+| `planCalls` | Amount of monthly calls included. |
+| `status` | Status of the token. |
+| `childTokens` | List of child or sub-tokens, if there are any associated with your account. |
+| `apiCalls` | An array of days and call volume amounts for each day. By default this will return data from the most recent 31 days. Use the `days` argument to adjust the response window. Dates prior to token becoming active will not be returned. |
+| &#x21B3;`date` |Date, e.g. `2015-10-01`. |
+| &#x21B3;`calls` | Total number of API calls made. |
+| &#x21B3;`proxyCalls` | Total number of calls made using proxy servers. [Read more](explain-using-different-proxies.md). |
+| &#x21B3;`giCalls` | Total number of search calls made against the [Global Index](explain-global-index.md). |
+| `invoices` | Array of invoices for paid accounts. |
+| &#x21B3;`date` | Date of invoice. |
+| &#x21B3;`periodStart` | Billing period start date (resolved to day). |
+| &#x21B3;`periodEnd` | Billing period end date (resolved to day). |
+| &#x21B3;`totalCalls` | Total calls made during the billing period. |
+| &#x21B3;`totalAmount` | Total amount charged. |
+| &#x21B3;`overageAmount` | Total overage amount billed if call volume exceeded included number of monthly calls. |
+| &#x21B3;`status` | Payment status of invoice (`paid` or `unpaid`). |

--- a/docs/api-analyze.md
+++ b/docs/api-analyze.md
@@ -4,123 +4,57 @@ title: Analyze API
 sidebar_label: Analyze API
 ---
 
-<div id="docBody">
-<p>The Diffbot Analyze API visually analyzes a web page, identifies its "page-type," and determines which Diffbot extraction API (if any) is appropriate. Pages that match a supported extraction API -- articles, discussions, images, products or videos -- <strong>will be automatically extracted</strong> and returned in the Analyze API response.</p>
-<p>Pages not currently supported by an extraction API will return "other."</p>
+The Diffbot Analyze API visually analyzes a web page, identifies its "page-type," and determines which Diffbot extraction API (if any) is appropriate. Pages that match a supported extraction API -- articles, discussions, images, products or videos -- **will be automatically extracted** and returned in the Analyze API response.
 
-<h3 id="request">Request</h3>
-<div class="indent">
-<p>To use the Analyze API, perform a HTTP GET request on the following endpoint:</p>
-  
+Pages not currently supported by an extraction API will return "other."
 
-```text
-https://api.diffbot.com/v3/analyze?token=...&amp;url=...
+## Request
+
+To use the Analyze API, perform a HTTP GET request on the following endpoint:
+
+```plaintext
+https://api.diffbot.com/v3/analyze?token=...&url=...
 ```
 
+Provide the following arguments:
 
-<p>Provide the following arguments:</p>
-
-<!--{arguments}--><table class="controls table table-bordered" id="arguments" border="0" cellpadding="5">
-<thead><tr>
-<th>Argument</th>
-<th>Description</th>
-</tr></thead>
-
-<tr>
-<td class=""><code>token</code></td>
-<td class=" default"><div>Developer token</div></td>
-</tr>
-<tr>
-<td class=""><code>url</code></td>
-<td class=" default"><div>Web page URL of the analyze to process (URL encoded)</div></td>
-</tr>
-
-<tr>
-<td colspan="2" class="header">Optional arguments</td>
-</tr>
-<tr>
-<td class=""><code>mode</code></td>
-<td class=" optional"><div>By default the Analyze API will fully extract all pages that match an existing Automatic API -- articles, products or image pages. Set <code>mode</code> to a specific page-type (e.g., <code>mode=article</code>) to extract content only from that specific page-type. All other pages will simply return the default Analyze fields.</div></td>
-</tr>
-<tr>
-<td class=""><code>fallback</code></td>
-<td class=" optional"><div>Force any non-extracted pages (those with a <code>type</code> of "other") through a specific API. For example, to route all "other" pages through the Article API, pass <code>&amp;fallback=article</code>. Pages that utilize this functionality will return a <code>fallbackType</code> field at the top-level of the response and a <code>originalType</code> field within each extracted object, both of which will indicate the fallback API used.</div></td>
-</tr>
-<tr>
-<td class=""><code>fields</code></td>
-<td class=" optional"><div>Specify optional fields to be returned from any fully-extracted pages, e.g.: <code>&amp;fields=querystring,links</code>.<br><br>See available fields within each API's individual documentation pages.</div></td>
-</tr>
-<tr>
-<td class=""><code>discussion</code></td>
-<td class=" optional"><div>Pass <code>discussion=false</code> to disable automatic extraction of comments or reviews from pages identified as articles or products. This will not affect pages identified as discussions.</div></td>
-</tr>
-<tr>
-<td class=""><code>timeout</code></td>
-<td class=" optional"><div>Sets a value in milliseconds to wait for the retrieval/fetch of content from the requested URL. The default timeout for the third-party response is 30 seconds (30000).</div></td>
-</tr>
-<tr>
-<td class=""><code>callback</code></td>
-<td class=" optional"><div>Use for jsonp requests. Needed for cross-domain ajax.</div></td>
-</tr>
-</table>
-<!--{endarguments}-->
+| Argument | Description |
+| :------- | :---------- |
+| `token` | Developer token |
+| `url` | Web page URL of the analyze to process (URL encoded)</td></tr><td colspan="2">**Optional arguments**</td> |
+| `mode` | By default the Analyze API will fully extract all pages that match an existing Automatic API -- articles, products or image pages. Set `mode` to a specific page-type (e.g., `mode=article`) to extract content only from that specific page-type. All other pages will simply return the default Analyze fields. |
+| `fallback` | Force any non-extracted pages (those with a `type` of "other") through a specific API. For example, to route all "other" pages through the Article API, pass `&fallback=article`. Pages that utilize this functionality will return a `fallbackType` field at the top-level of the response and a `originalType` field within each extracted object, both of which will indicate the fallback API used. |
+| `fields` | Specify optional fields to be returned from any fully-extracted pages, e.g.: `&fields=querystring,links`.<br><br>See available fields within each API's individual documentation pages. |
+| `discussion` | Pass `discussion=false` to disable automatic extraction of comments or reviews from pages identified as articles or products. This will not affect pages identified as discussions. |
+| `timeout` | Sets a value in milliseconds to wait for the retrieval/fetch of content from the requested URL. The default timeout for the third-party response is 30 seconds (30000). |
+| `callback` | Use for jsonp requests. Needed for cross-domain ajax.|
 
 
-</div>
-<h3 id="response">Response</h3>
-<p>The Analyze API returns data in JSON format.</p>
-<p>Each response includes a <code>request</code> object (which returns request-specific metadata), and an <code>objects</code> array, which will include the extracted information for all objects on a submitted page.</p>
-<p>If the Analyze API identifies the submitted page as an article, discussion thread, product or image, the associated object(s) from the page will be returned automatically in the <code>objects</code> array.</p>
-<p>The default fields returned:</p>
+## Response
 
-<!--{fields}--><table class="controls table table-bordered" id="fields" border="0" cellpadding="5">
-<thead><tr>
-<th>Field</th>
-<th>Description</th>
-</tr></thead>
+The Analyze API returns data in JSON format.
 
-<tr>
-<td class=""><code>title</code></td>
-<td class=" default"><div>Title of the page.</div></td>
-</tr>
-<tr>
-<td class=""><code>type</code></td>
-<td class=" default"><div>Page-type of the submitted URL, either <code>article</code>, <code>discussion</code>, <code>image</code>, <code>product</code>, <code>video</code> or -- if not a <a href="https://diffbot.com/products/automatic">supported page</a> -- <code>other</code>.</div></td>
-</tr>
-<tr>
-<td class=""><code>humanLanguage</code></td>
-<td class=" default"><div>Returns the (spoken/human) language of the submitted page, using two-letter <a href="http://en.wikipedia.org/wiki/List_of_ISO_639-1_codes" target="_blank">ISO 639-1 nomenclature</a>.</div></td>
-</tr>
+Each response includes a `request` object (which returns request-specific metadata), and an `objects` array, which will include the extracted information for all objects on a submitted page.
 
-<tr>
-<td colspan="2" class="header">Optional fields, available using <code>fields=</code> argument</td>
-</tr>
-<tr>
-<td class=""><code>links</code></td>
-<td class=" optional"><div>Returns a top-level object (<code>links</code>) containing all hyperlinks found on the page.</div></td>
-</tr>
-<tr>
-<td class=""><code>meta</code></td>
-<td class=" optional"><div>Returns a top-level object (<code>meta</code>) containing the full contents of page <code>meta</code> tags, including sub-arrays for <a href="http://ogp.me/" target="_new">OpenGraph</a> tags, <a href="https://dev.twitter.com/docs/cards/markup-reference" target="_new">Twitter Card</a> metadata, <a href="http://www.schema.org" target="_new">schema.org</a> microdata, and -- if available -- <a href="http://www.oembed.com" target="_new">oEmbed</a> metadata.</div></td>
-</tr>
-<tr>
-<td class=""><code>querystring</code></td>
-<td class=" optional"><div>Returns any key/value pairs present in the URL querystring. Items without a discrete value will be returned as <code>true</code>.</div></td>
-</tr>
-<tr>
-<td class=""><code>breadcrumb</code></td>
-<td class=" optional"><div>Returns a top-level array (<code>breadcrumb</code>) of URLs and link text from page breadcrumbs.</div></td>
-</tr>
-</table>
-<!--{endfields}-->
+If the Analyze API identifies the submitted page as an article, discussion thread, product or image, the associated object(s) from the page will be returned automatically in the `objects` array.
 
+The default fields returned:
 
-<h3 id="sampleresponse">Example Response</h3>
-<p>Because the below classified page is an article, its full contents are extracted using the Article API:</p>
-<div class="indent">
-  
+| Field | Description |
+| :---- | :---------- |
+| `title` | Title of the page. |
+| `type` | Page-type of the submitted URL, either `article`, `discussion`, `image`, `product`, `video` or -- if not a [supported page](https://diffbot.com/products/automatic) -- `other`. |
+| `humanLanguage` | Returns the (spoken/human) language of the submitted page, using two-letter [ISO 639-1 nomenclature](https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes).</td></tr><td colspan="2">**Optional fields, available using `fields=` argument**</td> |
+| `links` | Returns a top-level object (`links`) containing all hyperlinks found on the page. |
+| `meta` | Returns a top-level object (`meta`) containing the full contents of page `meta` tags, including sub-arrays for [OpenGraph](https://ogp.me/) tags, [Twitter Card](https://developer.twitter.com/en/docs/tweets/optimize-with-cards/overview/markup) metadata, [schema.org](https://www.schema.org) microdata, and -- if available -- [oEmbed](https://www.oembed.com) metadata. |
+| `querystring` | Returns any key/value pairs present in the URL querystring. Items without a discrete value will be returned as `true`. |
+| `breadcrumb` |Returns a top-level array (`breadcrumb`) of URLs and link text from page breadcrumbs. |
 
-```text
+## Example Response
+
+Because the below classified page is an article, its full contents are extracted using the Article API:
+
+```json
 {
   "request": {
     "pageUrl": "http://tcrn.ch/Jw7ZKw",
@@ -136,7 +70,7 @@ https://api.diffbot.com/v3/analyze?token=...&amp;url=...
       "resolvedPageUrl": "http://techcrunch.com/2012/05/31/diffbot-raises-2-million-seed-round-for-web-content-extraction-technology/",
       "pageUrl": "http://tcrn.ch/Jw7ZKw",
       "human_language": "en",
-      "text": "Diffbot , the super-geeky/awesome visual learning robot technology which aims to \"see\" the web the way that people do, is today announcing a new infusion of capital. The company has closed $2 million in funding from a number of technology veterans, including EarthLink founder Sky Dayton ; Andy Bechtolsheim , co-founder of Sun Microsystems; Joi Ito , Director of MIT Media Lab; Brad Garlinghouse , CEO of YouSendIt ( and formerly of TechCrunch parent company AOL ), Maynard Webb , Chairman of the Board at LiveOps, formerly eBay COO; Elad Gil , VP of Corporate Strategy at Twitter; Jonathan Heiliger , former VP of Technical Operations at Facebook; Redbeacon co-founder Aaron Lee ; and founder of VitalSigns Montgomery Kersten .\nMatrix Partners also participated in the round. Of the new investors, Sky Dayton will be the first to join Diffbot's board and will be taking an active role in the company, including plans to go hands-on with various Diffbot projects.\nLast August, the company publicly debuted its first APIs , which allow developers to build apps that can automatically extract meaning from web pages. For example, the Front Page API is able to analyze site homepages, and understands the difference between article text, headlines, bylines, ads, etc. The Article API can then extract clean article text, images and videos. Another example of Diffbot in action is the \"follow API,\" which can track the changes made to a website.\nToday, Diffbot has categorized the web into about 20 different page types, including homepages and article pages, which are the first two types it can now identity. Going forward, Diffbot plans train its bots to recognize all the other types of pages, including product pages, social networking profiles, recipe pages, review pages, and more.\nIts APIs have been put to use by AOL (again: disclosure, TC parent) in its news magazine AOL Editions , as well as by companies like Nuance , SocMetrics , and others. Diffbot says it's now processing 100 million API calls per month on behalf of its customers. Thousands of developers are using the APIs, the company notes, but paying customers are only in the \"tens.\" Correction: we're now told they have \"a lot more!\"\nDiffbot founder and CEO Michael Tung (aka \"Diffbot Mike\") says the new funding will be put towards new hires and expanding its resources. "More than that, we're receiving a huge vote of confidence from veterans who have built massive companies and understand the fine points of building for scale, maintaining uptime and delivering the absolute highest standards of service."\nTung is a patent attorney and Stanford PhD student who left the doctoral program to pursue Diffbot, thanks to seed funding from Stanford's incubator, StartX . Diffbot was StartX's first investment. With today's funding, Diffbot total raise is $2 million and change.",
+      "text": "Diffbot , the super-geeky/awesome visual learning robot technology which aims to \"see\" the web the way that people do, is today announcing a new infusion of capital. The company has closed $2 million in funding from a number of technology veterans, including EarthLink founder Sky Dayton ; Andy Bechtolsheim , co-founder of Sun Microsystems; Joi Ito , Director of MIT Media Lab; Brad Garlinghouse , CEO of YouSendIt ( and formerly of TechCrunch parent company AOL ), Maynard Webb , Chairman of the Board at LiveOps, formerly eBay COO; Elad Gil , VP of Corporate Strategy at Twitter; Jonathan Heiliger , former VP of Technical Operations at Facebook; Redbeacon co-founder Aaron Lee ; and founder of VitalSigns Montgomery Kersten .\nMatrix Partners also participated in the round. Of the new investors, Sky Dayton will be the first to join Diffbot's board and will be taking an active role in the company, including plans to go hands-on with various Diffbot projects.\nLast August, the company publicly debuted its first APIs , which allow developers to build apps that can automatically extract meaning from web pages. For example, the Front Page API is able to analyze site homepages, and understands the difference between article text, headlines, bylines, ads, etc. The Article API can then extract clean article text, images and videos. Another example of Diffbot in action is the \"follow API,\" which can track the changes made to a website.\nToday, Diffbot has categorized the web into about 20 different page types, including homepages and article pages, which are the first two types it can now identity. Going forward, Diffbot plans train its bots to recognize all the other types of pages, including product pages, social networking profiles, recipe pages, review pages, and more.\nIts APIs have been put to use by AOL (again: disclosure, TC parent) in its news magazine AOL Editions , as well as by companies like Nuance , SocMetrics , and others. Diffbot says it's now processing 100 million API calls per month on behalf of its customers. Thousands of developers are using the APIs, the company notes, but paying customers are only in the \"tens.\" Correction: we're now told they have \"a lot more!\"\nDiffbot founder and CEO Michael Tung (aka \"Diffbot Mike\") says the new funding will be put towards new hires and expanding its resources. \"More than that, we're receiving a huge vote of confidence from veterans who have built massive companies and understand the fine points of building for scale, maintaining uptime and delivering the absolute highest standards of service.\"\nTung is a patent attorney and Stanford PhD student who left the doctoral program to pursue Diffbot, thanks to seed funding from Stanford's incubator, StartX . Diffbot was StartX's first investment. With today's funding, Diffbot total raise is $2 million and change.",
       "title": "Diffbot Raises $2 Million Angel Round For Web Content Extraction Technology",
       "images": [
         {
@@ -146,52 +80,46 @@ https://api.diffbot.com/v3/analyze?token=...&amp;url=...
       ],
       "date": "Thu, 31 May 2012 07:00:00 GMT"
     }
+  ]
 }
 ```
 
+## Authentication
 
-</div>
+You can supply Diffbot with basic authentication credentials or custom HTTP headers (see below) to access intranet pages or other sites that require a login.
 
-<h3 id="authenticating">Authentication</h3>
-<p>You can supply Diffbot with basic authentication credentials or custom HTTP headers (see below) to access intranet pages or other sites that require a login.</p>
+### Basic Authentication
 
-<h4>Basic Authentication</h4>
-<p>To access pages that require a login/password (using <a href="http://en.wikipedia.org/wiki/Basic_access_authentication" target="_blank">basic access authentication</a>), include the username and password in your <code>url</code> parameter, e.g.: <code>url=http%3A%2F%2FUSERNAME:PASSWORD@www.diffbot.com</code>.</p>
+To access pages that require a login/password (using [basic access authentication](https://en.wikipedia.org/wiki/Basic_access_authentication)), include the username and password in your `url` parameter, e.g.: `url=http%3A%2F%2FUSERNAME:PASSWORD@www.diffbot.com`.
 
-<h3 id="customheaders">Custom HTTP Headers</h3>
-<p>You can supply Diffbot APIs with custom HTTP headers that will be passed along when making requests to third-party sites. These can be used to define specific Referer, User-Agent, Cookie or any other values.</p>
-<p>Custom headers should be sent as HTTP headers in your request to <code>https://api.diffbot.com</code>, and prepended with <code>X-Forward-</code>.</p>
-<p>For instance, to send custom <code>User-Agent</code>, <code>Referer</code> and <code>My-Custom-Header</code> header values:</p>
-<table class="controls table table-bordered" border="0" cellpadding="5">
-<thead><tr>
-<th>Desired Header</th>
-<th>Send to api.diffbot.com</th>
-</tr></thead>
-<tbody>
-<tr>
-<td><code>User-Agent:Diffbot</code></td>
-<td><code>X-Forward-User-Agent:Diffbot</code></td>
-</tr>
-<tr>
-<td><code>Referer:diffbot.com</code></td>
-<td><code>X-Forward-Referer:diffbot.com</code></td>
-</tr>
-<tr>
-<td><code>My-Custom-Header:CustomValue</code></td>
-<td><code>X-Forward-My-Custom-Header:CustomValue</code></td>
-</tr>
-</tbody>
-</table>
+## Custom HTTP Headers
 
-<h3 id="x-evaluate">Custom Javascript</h3>
+You can supply Diffbot APIs with custom HTTP headers that will be passed along when making requests to third-party sites. These can be used to define specific Referer, User-Agent, Cookie or any other values.
+
+Custom headers should be sent as HTTP headers in your request to `https://api.diffbot.com`, and prepended with `X-Forward-`.
+
+For instance, to send custom `User-Agent`, `Referer` and `My-Custom-Header` header values:
+
+| Desired Header | Send to api.diffbot.com |
+| :-- | :-- |
+| `User-Agent:Diffbot` | `X-Forward-User-Agent:Diffbot` |
+| `Referer:diffbot.com` | `X-Forward-Referer:diffbot.com` |
+| `My-Custom-Header:CustomValue` | `X-Forward-My-Custom-Header:CustomValue` |
+
+## Custom Javascript
+
 <div class="alert">This functionality is currently in beta.</div>
-<p>Using the <code>X-Evaluate</code> custom header (sent as <code>X-Forward-X-Evaluate</code>), you can inject your own Javascript code into web pages. Custom Javascript will be executed once the DOM has loaded.</p>
-<p>Custom Javascript should be provided as a text string and contained in its own function. You must also include the special functions <code>start()</code> and <code>end()</code> to indicate the beginning and end of your custom script. Once <code>end()</code> fires, the updated document will be processed by your chosen extraction API.</p>
-<p>It's recommended that your <code>end()</code> function be offset using <code>setTimeout</code> (see <a href="http://www.w3schools.com/js/js_timing.asp" target="_blank">JavaScript Timing Events</a>) in order to accommodate your primary function processing. Additionally, if your custom Javascript requires access to Ajax-delivered content, it may be necessary to offset your entire function using <code>setTimeout</code> in order to delay the start of your processing.</p>
-<p>The following sample <code>X-Evaluate</code> header waits one-half second after the DOM has loaded, enacts a click on the <code>a.loadMore</code> element, then waits 800 milliseconds before signaling the <code>end()</code>:</p>
+
+Using the `X-Evaluate` custom header (sent as `X-Forward-X-Evaluate`), you can inject your own Javascript code into web pages. Custom Javascript will be executed once the DOM has loaded.
+
+Custom Javascript should be provided as a text string and contained in its own function. You must also include the special functions `start()` and `end()` to indicate the beginning and end of your custom script. Once `end()` fires, the updated document will be processed by your chosen extraction API.
+
+It's recommended that your `end()` function be offset using `setTimeout` (see [JavaScript Timing Events](https://www.w3schools.com/js/js_timing.asp)) in order to accommodate your primary function processing. Additionally, if your custom Javascript requires access to Ajax-delivered content, it may be necessary to offset your entire function using `setTimeout` in order to delay the start of your processing.
+
+The following sample `X-Evaluate` header waits one-half second after the DOM has loaded, enacts a click on the `a.loadMore` element, then waits 800 milliseconds before signaling the `end()`:
 
 
-```text
+```js
 function() {
     start();
     setTimeout(function() {
@@ -208,35 +136,26 @@ function() {
 }
 ```
 
+Delivered as a string value as a custom header:
 
-
-<p>Delivered as a string value as a custom header:</p>
-
-
-```text
+```json
 "X-Forward-X-Evaluate": "function() {start();setTimeout(function(){var loadMoreNode=document.querySelector('a.loadMore');if (loadMoreNode != null) {loadMoreNode.click();setTimeout(function(){end();}, 800);} else {end();}},500);}"
 ```
 
+## Posting Content
 
+If your content is not publicly available (e.g., behind a firewall), you can POST markup or plain text directly to the Analyze API endpoint for analysis. Note that the quality of analysis is dependent on many factors, among them the accessibility of page assets (images, CSS) and how reliant the page layout is on those that are unavailable.
 
-<h3 id="posting">Posting Content</h3>
-<p>If your content is not publicly available (e.g., behind a firewall), you can POST markup or plain text directly to the Analyze API endpoint for analysis. Note that the quality of analysis is dependent on many factors, among them the accessibility of page assets (images, CSS) and how reliant the page layout is on those that are unavailable.</p>
-  
-
-```text
-https://api.diffbot.com/v3/analyze?token=...&amp;url=...
+```plaintext
+https://api.diffbot.com/v3/analyze?token=...&url=...
 ```
 
+Please note that the `url` argument is still required, and will be used to resolve any relative links contained in the markup.
 
-<p>Please note that the <code>url</code> argument is still required, and will be used to resolve any relative links contained in the markup.</p>
-<p>Provide the content to analyze as your POST body, and specify the <code>Content-Type</code> header as <code>text/html</code>.</p>
-<p><strong>HTML Post Sample</strong>:</p>
-  
+Provide the content to analyze as your POST body, and specify the `Content-Type` header as `text/html`.
 
-```text
-curl -H "Content-Type: text/html" -d '&lt;html&gt;&lt;head&gt;&lt;title&gt;Something to Buy&lt;/title&gt;&lt;/head&gt;&lt;body&gt;&lt;h2&gt;A Pair of Jeans&lt;/h2&gt;&lt;div&gt;Price: $31.99&lt;/div&gt;&lt;/body&gt;&lt;/html&gt;' 'https://api.diffbot.com/v3/analyze?token=...&amp;url=http%3A%2F%2Fstore.diffbot.com'
+### HTML Post Sample
+
+```plaintext
+curl -H "Content-Type: text/html" -d '<html><head><title>Something to Buy</title></head><body><h2>A Pair of Jeans</h2><div>Price: $31.99</div></body></html>' 'https://api.diffbot.com/v3/analyze?token=...&url=http%3A%2F%2Fstore.diffbot.com'
 ```
-
-
-
-</div>

--- a/docs/api-article-html.md
+++ b/docs/api-article-html.md
@@ -4,225 +4,57 @@ title: Article API: HTML Field Specification
 sidebar_label: Article API: HTML Field Specification
 ---
 
-<div id="docBody" style="overflow-y:scroll;height:800px;">
-<h3 id="htmlspec">HTML Field Specification</h3>
-<p>Diffbot's <code>html</code> field returns normalized HTML maintaining the structure and layout of the source article, while standardizing its element and attributes for reliable parsing and processing. Content will be normalized into the following elements and attributes:
+Diffbot's `html` field returns normalized HTML maintaining the structure and layout of the source article, while standardizing its element and attributes for reliable parsing and processing. Content will be normalized into the following elements and attributes:
 
-</p>
-<table class="controls table table-bordered" border="0" cellpadding="5">
-<thead>
-<tr>
-<th>Element</th>
-<th>Attributes</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td><code>*</code></td>
-<td><code>data-*</code></td>
-<td>As of January 2017 normalized HTML will retain and return <a href="http://www.w3schools.com/tags/att_global_data.asp" target="_blank">data-*</a> attributes.</td>
-</tr>
-<tr>
-<td colspan="3"><em>Block elements</em></td>
-</tr>
-<tr>
-<td><code>p</code></td>
-<td class="empty">—</td>
-<td>Unless returned within a more specific element below, all text will be returned within <code>p</code> elements at the top-level of the HTML response.</td>
-</tr>
-<tr>
-<td>
-<code>h1</code> - <code>h5</code>
-</td>
-<td class="empty">—</td>
-<td>Headers will be maintained if originally provided.</td>
-</tr>
-<tr>
-<td><code>aside</code></td>
-<td class="empty">—</td>
-<td>Returned at top-level of HTML response.</td>
-</tr>
-<tr>
-<td><code>blockquote</code></td>
-<td class="empty">—</td>
-<td>Returned at top-level of HTML response.</td>
-</tr>
-<tr>
-<td>
-<code>code</code>, <code>pre</code>
-</td>
-<td class="empty">—</td>
-<td>Returned at top-level of HTML response.</td>
-</tr>
-<tr>
-<td>
-<code>ul</code>, <code>ol</code>
-</td>
-<td class="empty"><code>start</code></td>
-<td>Returned at top-level of HTML response.</td>
-</tr>
-<tr>
-<td class="indent"><code>li</code></td>
-<td class="empty">—</td>
-<td></td>
-</tr>
-<tr>
-<td><code>table</code></td>
-<td></td>
-<td>Original content within <code>table</code> elements will be largely retained, including images and other media items.</td>
-</tr>
-<tr>
-<td class="indent"><code>tbody</code></td>
-<td class="empty">—</td>
-<td></td>
-</tr>
-<tr>
-<td class="indent"><code>th</code></td>
-<td class="empty">—</td>
-<td></td>
-</tr>
-<tr>
-<td class="indent"><code>tr</code></td>
-<td class="empty">—</td>
-<td></td>
-</tr>
-<tr>
-<td class="indent"><code>td</code></td>
-<td>
-<code>valign</code>, <code>colspan</code>
-</td>
-<td></td>
-</tr>
-<tr>
-<td><code>dl</code></td>
-<td class="empty">—</td>
-<td>Returned at top-level of HTML response.</td>
-</tr>
-<tr>
-<td class="indent"><code>dt</code></td>
-<td class="empty">—</td>
-<td></td>
-</tr>
-<tr>
-<td class="indent"><code>dd</code></td>
-<td class="empty">—</td>
-<td></td>
-</tr>
-<tr><td colspan="3"><em>Inline elements</em></td></tr>
-<tr>
-<td><code>br</code></td>
-<td class="empty">—</td>
-<td>Single linebreaks entities will be maintained in markup and returned as <code>&lt;br&gt;</code>. Double-linebreaks will be removed and surrounding content will be returned within <code>p</code> block elements.</td>
-</tr>
-<tr>
-<td>
-<code>b</code>, <code>strong</code>
-</td>
-<td class="empty">—</td>
-<td>Inline emphasis tags will be retained inside of other elements.</td>
-</tr>
-<tr>
-<td>
-<code>i</code>, <code>em</code>
-</td>
-<td class="empty">—</td>
-<td></td>
-</tr>
-<tr>
-<td><code>u</code></td>
-<td class="empty">—</td>
-<td></td>
-</tr>
-<tr>
-<td><code>sup</code></td>
-<td class="empty">—</td>
-<td></td>
-</tr>
-<tr>
-<td><code>sub</code></td>
-<td class="empty">—</td>
-<td></td>
-</tr>
-<tr>
-<td><code>a</code></td>
-<td><code>href</code></td>
-<td>Anchor tags and their <code>href</code> values will be retained.</td>
-</tr>
-<tr><td colspan="3"><em>Media</em></td></tr>
-<tr>
-<td><code>figure</code></td>
-<td class="empty">—</td>
-<td>Media elements will be returned at the top-level of the HTML content and contained within <code>figure</code> tags.</td>
-</tr>
-<tr>
-<td><code>img</code></td>
-<td>
-<code>src</code>, <code>alt</code>, <code>srcset</code>, <code>sizes</code>
-</td>
-<td>Image layout specifics (floats, etc.) and CSS-specified widths/heights will be discarded.</td>
-</tr>
-<tr>
-<td>
-<code>video</code>/<code>audio</code>
-</td>
-<td><code>src</code></td>
-<td>The child <code>source</code> elements within <code>video</code> and <code>audio</code> elements will be retained along with the <code>type</code> attribute, if provided.</td>
-</tr>
-<tr>
-<td class="indent"><code>source</code></td>
-<td>
-<code>src</code>, <code>type</code>, <code>srcset</code>, <code>sizes</code>
-</td>
-<td></td>
-</tr>
-<tr>
-<td><code>figcaption</code></td>
-<td class="empty">—</td>
-<td>If present, media captions will be returned as <code>figcaption</code> elements within the <code>figure</code> container.</td>
-</tr>
-<tr>
-<td><code>iframe</code></td>
-<td>
-<code>src</code>, <code>frameborder</code>
-</td>
-<td></td>
-</tr>
-<tr>
-<td>
-<code>embed</code>, <code>object</code>
-</td>
-<td>
-<code>src</code>, <code>type</code>
-</td>
-<td></td>
-</tr>
-</tbody>
-</table>
+| Element | Attributes | Description |
+| :------ | :--------- | :---------- |
+| `*` | `data-*` | As of January 2017 normalized HTML will retain and return [data-&#42;](https://www.w3schools.com/tags/att_global_data.asp) attributes.</td></tr><td colspan="3">*Block elements*</td> |
+| `p` | -- | Unless returned within a more specific element below, all text will be returned within `p` elements at the top-level of the HTML response. |
+| `h1` - `h5` | -- | Headers will be maintained if originally provided. |
+| `aside` | -- | Returned at top-level of HTML response. |
+| `blockquote` | -- | Returned at top-level of HTML response. |
+| `code`, `pre` | -- | Returned at top-level of HTML response. |
+| `ul`, `ol` | `start` | Returned at top-level of HTML response. |
+| &#x21B3;`li` | -- | |
+| `table` | -- | Original content within `table` elements will be largely retained, including images and other media items. |
+| &#x21B3;`tbody` | -- | |
+| &#x21B3;`th` | -- | |
+| &#x21B3;`tr` | -- | |
+| &#x21B3;`td` | `valign`, `colspan` | |
+| `dl` | -- | Returned at top-level of HTML response. |
+| &#x21B3;`dt` | -- | |
+| &#x21B3;`dd` | -- | </td></tr><td colspan="3">*Inline elements*</td> |
+| `br` | -- | Single linebreaks entities will be maintained in markup and returned as `<br>`. Double-linebreaks will be removed and surrounding content will be returned within `p` block elements. |
+| `b`, `strong` | -- | Inline emphasis tags will be retained inside of other elements. |
+| `i`, `em` | -- | |
+| `u` | -- | |
+| `sup` | -- | |
+| `sub` | -- | |
+| `a` | `href` | Anchor tags and their `href` values will be retained. </td></tr><td colspan="3">*Media*</td> |
+| `figure` | -- | Media elements will be returned at the top-level of the HTML content and contained within `figure` tags. |
+| `img` | `src`, `alt`, `srcset`, `sizes` | Image layout specifics (floats, etc.) and CSS-specified widths/heights will be discarded. |
+| `video`/`audio` | `src` | The child `source` elements within `video` and `audio` elements will be retained along with the `type` attribute, if provided. |
+| &#x21B3;`source` | `src`, `type`, `srcset`, `sizes` | |
+| `figcaption` | -- | If present, media captions will be returned as `figcaption` elements within the `figure` container. |
+| `iframe` | `src`, `frameborder` | |
+| `embed`, `object` | `src`, `type` | |
 
-<h3 id="htmlspec">Example HTML Response</h3>
+## Example HTML Response
 
+```html
+<p>Diffbot's human wranglers are proud today to announce the release of our newest product: an API for... products!</p>
 
-```text
+<p>The <a href="http://www.diffbot.com/products/automatic/product">Product API</a> can be used for extracting clean, structured data from any e-commerce product page. It automatically makes available all the product data you'd expect: price, discount/savings amount, shipping cost, product description, any relevant product images, SKU and/or other product IDs.</p>
 
-&lt;p&gt;Diffbot's human wranglers are proud today to announce the release of our newest product: an API for... products!&lt;/p&gt;
+<p>Even cooler: pair the Product API with <a href="http://www.diffbot.com/products/crawlbot">Crawlbot</a>, our intelligent site-spidering tool, and let Diffbot determine which pages are products, then automatically structure the entire catalog. Here's a quick demonstration of Crawlbot at work:</p>
 
-&lt;p&gt;The &lt;a href="http://www.diffbot.com/products/automatic/product"&gt;Product API&lt;/a&gt; can be used for extracting clean, structured data from any e-commerce product page. It automatically makes available all the product data you'd expect: price, discount/savings amount, shipping cost, product description, any relevant product images, SKU and/or other product IDs.&lt;/p&gt;
+<figure>
+  <iframe frameborder="0" src="http://www.youtube.com/embed/lfcri5ungRo?feature=oembed"></iframe>
+</figure>
 
-&lt;p&gt;Even cooler: pair the Product API with &lt;a href="http://www.diffbot.com/products/crawlbot"&gt;Crawlbot&lt;/a&gt;, our intelligent site-spidering tool, and let Diffbot determine which pages are products, then automatically structure the entire catalog. Here's a quick demonstration of Crawlbot at work:&lt;/p&gt;
+<p>We've developed the Product API over the course of two years, building upon our core vision technology that's extracted structured data from billions of web pages, and training our machine learning systems using data from tens of thousands of unique shopping sites. We can't wait for you to try it out.</p>
 
-&lt;figure&gt;
-  &lt;iframe frameborder="0" src="http://www.youtube.com/embed/lfcri5ungRo?feature=oembed"&gt;&lt;/iframe&gt;
-&lt;/figure&gt;
+<p>What are you waiting for? Check out the <a href="http://www.diffbot.com/products/automatic/product">Product API documentation</a> and dive on in! If you need a token, check out our <a href="http://www.diffbot.com/pricing">pricing and plans</a> (including our Free plan).</p>
 
-&lt;p&gt;We've developed the Product API over the course of two years, building upon our core vision technology that's extracted structured data from billions of web pages, and training our machine learning systems using data from tens of thousands of unique shopping sites. We can't wait for you to try it out.&lt;/p&gt;
-
-&lt;p&gt;What are you waiting for? Check out the &lt;a href="http://www.diffbot.com/products/automatic/product"&gt;Product API documentation&lt;/a&gt; and dive on in! If you need a token, check out our &lt;a href="http://www.diffbot.com/pricing"&gt;pricing and plans&lt;/a&gt; (including our Free plan).&lt;/p&gt;
-
-&lt;p&gt;Questions? Hit us up at &lt;a href="mailto:support@diffbot.com"&gt;support@diffbot.com&lt;/a&gt;.&lt;/p&gt;
-
+<p>Questions? Hit us up at <a href="mailto:support@diffbot.com">support@diffbot.com</a>.</p>
 ```
-
-
-
-</div>

--- a/docs/api-article.md
+++ b/docs/api-article.md
@@ -5,308 +5,118 @@ sidebar_label: Article Extraction API
 todo: Modify links to old API docs
 ---
 
-<div id="docBody">
-
-<p>The Article API is used to extract clean article text and other data from news articles, blog posts and other text-heavy pages. Retrieve the full-text, cleaned and <a href="html/">normalized HTML</a>, related images and videos, author, date, tags—automatically, from any article on any site.</p>
+The Article API is used to extract clean article text and other data from news articles, blog posts and other text-heavy pages. Retrieve the full-text, cleaned and [normalized HTML](api-article-html.md), related images and videos, author, date, tags—automatically, from any article on any site.
 
 
-<h3 id="request">Request</h3>
-<p>To use the Article API, perform a HTTP GET request on the following endpoint:</p>
-  
+## Request
 
-```text
+To use the Article API, perform a HTTP GET request on the following endpoint:
+
+```plaintext
 https://api.diffbot.com/v3/article
 ```
 
+Provide the following arguments:
 
-<p>Provide the following arguments:</p>
+| Argument | Description |
+| :------- | :---------- |
+| `token` | Developer token |
+| `url` | Web page URL of the article to process (URL encoded) </td></tr><td colspan="2">**Optional arguments**</td> |
+| `fields` | Used to specify optional fields to be returned by the Article API. See the [Fields](#the-fields-argument) section below. |
+| `paging` | Pass `paging=false` to disable automatic concatenation of multiple-page articles. (By default, Diffbot will concatenate up to 20 pages of a single article.) [More on automatic concatenation](guides-multi-page-articles-discussions.md). |
+| `maxTags` | Set the maximum number of automatically-generated tags to return. By default a maximum of ten tags will be returned. |
+| `tagConfidence` | Set the minimum relevance `score` of tags to return, between 0.0 and 1.0. By default only tags with a score equal to or above 0.5 will be returned. |
+| `discussion` | Pass `discussion=false` to disable automatic extraction of article comments. See [below](#comment-extraction). |
+| `timeout` | Sets a value in milliseconds to wait for the retrieval/fetch of content from the requested URL. The default timeout for the third-party response is 30 seconds (30000). |
+| `callback` | Use for jsonp requests. Needed for cross-domain ajax. |
 
-<!--{arguments}--><table class="controls table table-bordered" id="arguments" border="0" cellpadding="5">
-<thead><tr>
-<th>Argument</th>
-<th>Description</th>
-</tr></thead>
+### The fields argument
 
-<tr>
-<td class=""><code>token</code></td>
-<td class=" default"><div>Developer token</div></td>
-</tr>
-<tr>
-<td class=""><code>url</code></td>
-<td class=" default"><div>Web page URL of the article to process (URL encoded)</div></td>
-</tr>
+Use the `fields` argument to return optional fields in the JSON response. The default fields will always be returned. For nested arrays, use parentheses to retrieve specific fields, or `*` to return all sub-fields.
 
-<tr>
-<td colspan="2" class="header">Optional arguments</td>
-</tr>
-<tr>
-<td class=""><code>fields</code></td>
-<td class=" optional"><div>Used to specify optional fields to be returned by the Article API. See the <a href="#fields">Fields</a> section below.</div></td>
-</tr>
-<tr>
-<td class=""><code>paging</code></td>
-<td class=" optional"><div>Pass <code>paging=false</code> to disable automatic concatenation of multiple-page articles. (By default, Diffbot will concatenate up to 20 pages of a single article.) <a href="guides-multi-page-articles-discussions">More on automatic concatenation</a>.</div></td>
-</tr>
-<tr>
-<td class=""><code>maxTags</code></td>
-<td class=" optional"><div>Set the maximum number of automatically-generated tags to return. By default a maximum of ten tags will be returned.</div></td>
-</tr>
-<tr>
-<td class=""><code>tagConfidence</code></td>
-<td class=" optional"><div>Set the minimum relevance <code>score</code> of tags to return, between 0.0 and 1.0. By default only tags with a score equal to or above 0.5 will be returned.</div></td>
-</tr>
-<tr>
-<td class=""><code>discussion</code></td>
-<td class=" optional"><div>Pass <code>discussion=false</code> to disable automatic extraction of article comments. See <a href="#discussion">below</a>.</div></td>
-</tr>
-<tr>
-<td class=""><code>timeout</code></td>
-<td class=" optional"><div>Sets a value in milliseconds to wait for the retrieval/fetch of content from the requested URL. The default timeout for the third-party response is 30 seconds (30000).</div></td>
-</tr>
-<tr>
-<td class=""><code>callback</code></td>
-<td class=" optional"><div>Use for jsonp requests. Needed for cross-domain ajax.</div></td>
-</tr>
-</table>
-<!--{endarguments}-->
+For example, to return `links` and `meta` (in addition to the default fields), your `&fields` argument would be:
 
-<h4>The fields argument</h4>
-<p>Use the <code>fields</code> argument to return optional fields in the JSON response. The default fields will always be returned. For nested arrays, use parentheses to retrieve specific fields, or <code>*</code> to return all sub-fields.</p>
-<p>For example, to return <code>links</code> and <code>meta</code> (in addition to the default fields), your &amp;fields argument would be:</p>
-  
-
-```text
-&amp;fields=links,meta
+```plaintext
+&fields=links,meta
 ```
 
+## Response
 
+The Article API returns data in JSON format.
 
+Each V3 response includes a `request` object (which returns request-specific metadata), and an `objects` array, which will include the extracted information for all objects on a submitted page. At the moment, **only a single object** will be returned for Article API requests.
 
-<h3 id="response">Response</h3>
-<p>The Article API returns data in JSON format.</p>
-<p>Each V3 response includes a <code>request</code> object (which returns request-specific metadata), and an <code>objects</code> array, which will include the extracted information for all objects on a submitted page. At the moment, <strong>only a single object</strong> will be returned for Article API requests.</p>
-<p>Objects in the Article API's <code>objects</code> array will include the following fields:</p>
+Objects in the Article API's `objects` array will include the following fields:
 
+| Field | Description |
+| :---- | :---------- |
+| `type` | Type of object (always `article`). |
+| `title` | Title of the article. |
+| `text` | Full text of the article. |
+| `html` | Diffbot-normalized HTML of the extracted article. Please see the [HTML Specification](api-article-html.md) for a breakdown of elements and attributes returned. |
+| `date` | Date of extracted article, normalized in most cases to [RFC 1123 (HTTP/1.1)](https://www.w3.org/Protocols/rfc2616/rfc2616-sec3.html#sec3.3). |
+| `estimatedDate` | If an article's date is ambiguous, Diffbot will attempt to estimate a more specific timestamp using various factors. This will not be generated for articles older than two days, or articles without an identified `date`. |
+| `author` | Article author. |
+| `authorUrl` | URL of the author profile page, if available. |
+| `discussion` | Article comments, as extracted by the Diffbot Discussion API. See [below](#comment-extraction). |
+| `humanLanguage` | Returns the (spoken/human) language of the submitted page, using two-letter [ISO 639-1 nomenclature](https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes). |
+| `numPages` | Number of pages automatically concatenated to form the `text` or `html` response. By default, Diffbot will automatically concatenate up to 20 pages of an article. [More on automatic concatenation](guides-multi-page-articles-discussions.md). |
+| `nextPages` | Array of all page URLs concatenated in a multipage article. [More on automatic concatenation](guides-multi-page-articles-discussions.md). |
+| `siteName` | The plain-text name of the site (e.g. `The New York Times` or `Diffbot`). If no site name is automatically determined, the root domain (`diffbot.com`) will be returned. |
+| `publisherRegion` | If known, the region of the article publication. |
+| `publisherCountry` | If known, the country of the article publication. |
+| `pageUrl` | URL of submitted page / page from which the article is extracted. |
+| `resolvedPageUrl` | Returned if the `pageUrl` redirects to another URL. |
+| `tags` | Array of tags/entities, generated from analysis of the extracted `text` and cross-referenced with [DBpedia](https://wiki.dbpedia.org/About) and other data sources. Language-specific tags will be returned if the source text is in English, Chinese, French, German, Spanish or Russian. |
+| &#x21B3;`label` | Name of the entity or tag. |
+| &#x21B3;`count` | Number of appearances the entity makes within the text content. |
+| &#x21B3;`score` | Rating of the entity's relevance to the overall text content (range of 0 to 1) based on various factors. |
+| &#x21B3;`rdfTypes` | If the entity can be represented by multiple resources, all of the possible URIs will be returned. |
+| &#x21B3;`type` | This legacy field is a simplified precursor to `rdfTypes`, and will return either `organization` or `person` if the entity is either of those types. |
+| &#x21B3;`uri` | Link to the primary Diffbot entity for this tag in the [Diffbot Knowledge Graph](https://www.diffbot.com/knowledge-graph/). On older articles, this might be the URI to the entity at DBpedia or another data source, but in most cases it will lead to Diffbot's KG entry which will contain more information about the tag. |
+| `images` | Array of images, if present within the article body. |
+| &#x21B3;`url` |Fully resolved link to image. If the image `SRC` is encoded as base64 data, the complete data URI will be returned. |
+| &#x21B3;`title` | Description or caption of the image. |
+| &#x21B3;`height` | Height of image as (re-)sized via browser/CSS. |
+| &#x21B3;`width` | Width of image as (re-)sized via browser/CSS. |
+| &#x21B3;`naturalHeight` | Raw image height, in pixels. |
+| &#x21B3;`naturalWidth` | Raw image width, in pixels. |
+| &#x21B3;`primary` | Returns `true` if image is identified as primary based on visual analysis. |
+| &#x21B3;`diffbotUri` | Internal ID used for indexing. |
+| `videos` | Array of videos, if present within the article body. |
+| &#x21B3;`url` | Fully resolved link to source video content. |
+| &#x21B3;`naturalHeight` | Source video height, in pixels, if available. |
+| &#x21B3;`naturalWidth` | Source video width, in pixels, if available. |
+| &#x21B3;`primary` | Returns `true` if video is identified as primary based on visual analysis. |
+| &#x21B3;`diffbotUri` | Internal ID used for indexing. |
+| `breadcrumb` | Returns a top-level array (`breadcrumb`) of URLs and link text from page breadcrumbs. |
+| `diffbotUri` | Unique object ID. The `diffbotUri` is generated from the values of various Article fields and uniquely identifies the object. This can be used for deduplication. </td></tr><td colspan="2">**Optional fields, available using `fields=` argument**</td> |
+| `quotes` | Returns quotes found in the article text and who said them. For English-language text only. |
+| `sentiment` | Returns the sentiment score of the analyzed article text, a value ranging from -1.0 (very negative) to 1.0 (very positive). For English-language text only. |
+| `links` | Returns a top-level object (`links`) containing all hyperlinks found on the page. |
+| `meta` | Returns a top-level object (`meta`) containing the full contents of page `meta` tags, including sub-arrays for [OpenGraph](https://ogp.me/) tags, [Twitter Card](https://developer.twitter.com/en/docs/tweets/optimize-with-cards/overview/markup) metadata, [schema.org](https://www.schema.org) microdata, and -- if available -- [oEmbed](https://www.oembed.com) metadata. |
+| `querystring` | Returns any key/value pairs present in the URL querystring. Items without a discrete value will be returned as `true`. |
 
-<!--{fields}--><table class="controls table table-bordered" id="fields" border="0" cellpadding="5">
-<thead><tr>
-<th>Field</th>
-<th>Description</th>
-</tr></thead>
+## Comment Extraction
 
-<tr>
-<td class=""><code>type</code></td>
-<td class=" default"><div>Type of object (always <code>article</code>).</div></td>
-</tr>
-<tr>
-<td class=""><code>title</code></td>
-<td class=" default"><div>Title of the article.</div></td>
-</tr>
-<tr>
-<td class=""><code>text</code></td>
-<td class=" default"><div>Full text of the article.</div></td>
-</tr>
-<tr>
-<td class=""><code>html</code></td>
-<td class=" default"><div>Diffbot-normalized HTML of the extracted article. Please see the <a href="api-article-html">HTML Specification</a> for a breakdown of elements and attributes returned.</div></td>
-</tr>
-<tr>
-<td class=""><code>date</code></td>
-<td class=" default"><div>Date of extracted article, normalized in most cases to <a href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec3.html#sec3.3">RFC 1123 (HTTP/1.1)</a>.</div></td>
-</tr>
-<tr>
-<td class=""><code>estimatedDate</code></td>
-<td class=" default"><div>If an article's date is ambiguous, Diffbot will attempt to estimate a more specific timestamp using various factors. This will not be generated for articles older than two days, or articles without an identified <code>date</code>.</div></td>
-</tr>
-<tr>
-<td class=""><code>author</code></td>
-<td class=" default"><div>Article author.</div></td>
-</tr>
-<tr>
-<td class=""><code>authorUrl</code></td>
-<td class=" default"><div>URL of the author profile page, if available.</div></td>
-</tr>
-<tr>
-<td class=""><code>discussion</code></td>
-<td class=" default"><div>Article comments, as extracted by the Diffbot Discussion API. See <a href="#discussion">below</a>.</div></td>
-</tr>
-<tr>
-<td class=""><code>humanLanguage</code></td>
-<td class=" default"><div>Returns the (spoken/human) language of the submitted page, using two-letter <a href="http://en.wikipedia.org/wiki/List_of_ISO_639-1_codes" target="_blank">ISO 639-1 nomenclature</a>.</div></td>
-</tr>
-<tr>
-<td class=""><code>numPages</code></td>
-<td class=" default"><div>Number of pages automatically concatenated to form the <code>text</code> or <code>html</code> response. By default, Diffbot will automatically concatenate up to 20 pages of an article. <a href="guides-multi-page-articles-discussions">More on automatic concatenation</a>.</div></td>
-</tr>
-<tr>
-<td class=""><code>nextPages</code></td>
-<td class=" default"><div>Array of all page URLs concatenated in a multipage article. <a href="guides-multi-page-articles-discussions">More on automatic concatenation</a>.</div></td>
-</tr>
-<tr>
-<td class=""><code>siteName</code></td>
-<td class=" default"><div>The plain-text name of the site (e.g. <code>The New York Times</code> or <code>Diffbot</code>). If no site name is automatically determined, the root domain (<code>diffbot.com</code>) will be returned.</div></td>
-</tr>
-<tr>
-<td class=""><code>publisherRegion</code></td>
-<td class=" default"><div>If known, the region of the article publication.</div></td>
-</tr>
-<tr>
-<td class=""><code>publisherCountry</code></td>
-<td class=" default"><div>If known, the country of the article publication.</div></td>
-</tr>
-<tr>
-<td class=""><code>pageUrl</code></td>
-<td class=" default"><div>URL of submitted page / page from which the article is extracted.</div></td>
-</tr>
-<tr>
-<td class=""><code>resolvedPageUrl</code></td>
-<td class=" default"><div>Returned if the <code>pageUrl</code> redirects to another URL.</div></td>
-</tr>
-<tr>
-<td class="parent"><code>tags</code></td>
-<td class="parent default"><div>Array of tags/entities, generated from analysis of the extracted <code>text</code> and cross-referenced with <a href="http://wiki.dbpedia.org/About" target="_new">DBpedia</a> and other data sources. Language-specific tags will be returned if the source text is in English, Chinese, French, German, Spanish or Russian.</div></td>
-</tr>
-<tr>
-<td class="tags indent"><code>label</code></td>
-<td class="tags indent default"><div>Name of the entity or tag.</div></td>
-</tr>
-<tr>
-<td class="tags indent"><code>count</code></td>
-<td class="tags indent default"><div>Number of appearances the entity makes within the text content.</div></td>
-</tr>
-<tr>
-<td class="tags indent"><code>score</code></td>
-<td class="tags indent default"><div>Rating of the entity's relevance to the overall text content (range of 0 to 1) based on various factors.</div></td>
-</tr>
-<tr>
-<td class="tags indent"><code>rdfTypes</code></td>
-<td class="tags indent default"><div>If the entity can be represented by multiple resources, all of the possible URIs will be returned.</div></td>
-</tr>
-<tr>
-<td class="tags indent"><code>type</code></td>
-<td class="tags indent default"><div>This legacy field is a simplified precursor to <code>rdfTypes</code>, and will return either <code>organization</code> or <code>person</code> if the entity is either of those types.</div></td>
-</tr>
-<tr>
-<td class="tags indent"><code>uri</code></td>
-<td class="tags indent default"><div>Link to the primary Diffbot entity for this tag in the <a href="https://www.diffbot.com/knowledge-graph/">Diffbot Knowledge Graph</a>. On older articles, this might be the URI to the entity at DBpedia or another data source, but in most cases it will lead to Diffbot's KG entry which will contain more information about the tag.</div></td>
-</tr>
-<tr>
-<td class="parent"><code>images</code></td>
-<td class="parent default"><div>Array of images, if present within the article body.</div></td>
-</tr>
-<tr>
-<td class="images indent"><code>url</code></td>
-<td class="images indent default"><div>Fully resolved link to image. If the image <code>SRC</code> is encoded as base64 data, the complete data URI will be returned.</div></td>
-</tr>
-<tr>
-<td class="images indent"><code>title</code></td>
-<td class="images indent default"><div>Description or caption of the image.</div></td>
-</tr>
-<tr>
-<td class="images indent"><code>height</code></td>
-<td class="images indent default"><div>Height of image as (re-)sized via browser/CSS.</div></td>
-</tr>
-<tr>
-<td class="images indent"><code>width</code></td>
-<td class="images indent default"><div>Width of image as (re-)sized via browser/CSS.</div></td>
-</tr>
-<tr>
-<td class="images indent"><code>naturalHeight</code></td>
-<td class="images indent default"><div>Raw image height, in pixels.</div></td>
-</tr>
-<tr>
-<td class="images indent"><code>naturalWidth</code></td>
-<td class="images indent default"><div>Raw image width, in pixels.</div></td>
-</tr>
-<tr>
-<td class="images indent"><code>primary</code></td>
-<td class="images indent default"><div>Returns <code>true</code> if image is identified as primary based on visual analysis.</div></td>
-</tr>
-<tr>
-<td class="images indent"><code>diffbotUri</code></td>
-<td class="images indent default"><div>Internal ID used for indexing.</div></td>
-</tr>
-<tr>
-<td class="parent"><code>videos</code></td>
-<td class="parent default"><div>Array of videos, if present within the article body.</div></td>
-</tr>
-<tr>
-<td class="videos indent"><code>url</code></td>
-<td class="videos indent default"><div>Fully resolved link to source video content.</div></td>
-</tr>
-<tr>
-<td class="videos indent"><code>naturalHeight</code></td>
-<td class="videos indent default"><div>Source video height, in pixels, if available.</div></td>
-</tr>
-<tr>
-<td class="videos indent"><code>naturalWidth</code></td>
-<td class="videos indent default"><div>Source video width, in pixels, if available.</div></td>
-</tr>
-<tr>
-<td class="videos indent"><code>primary</code></td>
-<td class="videos indent default"><div>Returns <code>true</code> if video is identified as primary based on visual analysis.</div></td>
-</tr>
-<tr>
-<td class="videos indent"><code>diffbotUri</code></td>
-<td class="videos indent default"><div>Internal ID used for indexing.</div></td>
-</tr>
-<tr>
-<td class=""><code>breadcrumb</code></td>
-<td class=" default"><div>Returns a top-level array (<code>breadcrumb</code>) of URLs and link text from page breadcrumbs.</div></td>
-</tr>
-<tr>
-<td class=""><code>diffbotUri</code></td>
-<td class=" default"><div>Unique object ID. The <code>diffbotUri</code> is generated from the values of various Article fields and uniquely identifies the object. This can be used for deduplication.</div></td>
-</tr>
+By default the Article API will attempt to extract comments from article pages, using integrated functionality from the Diffbot Discussion API. Comment data will be returned in the `discussion` object (nested within the primary article object). The full syntax for discussion data is available in the [Discussion API documentation](api-discussion).
 
-<tr>
-<td colspan="2" class="header">Optional fields, available using <code>fields=</code> argument</td>
-</tr>
-<tr>
-<td class=""><code>quotes</code></td>
-<td class=" optional"><div>Returns quotes found in the article text and who said them. For English-language text only.</div></td>
-</tr>
-<tr>
-<td class=""><code>sentiment</code></td>
-<td class=" optional"><div>Returns the sentiment score of the analyzed article text, a value ranging from -1.0 (very negative) to 1.0 (very positive). For English-language text only.</div></td>
-</tr>
-<tr>
-<td class=""><code>links</code></td>
-<td class=" optional"><div>Returns a top-level object (<code>links</code>) containing all hyperlinks found on the page.</div></td>
-</tr>
-<tr>
-<td class=""><code>meta</code></td>
-<td class=" optional"><div>Returns a top-level object (<code>meta</code>) containing the full contents of page <code>meta</code> tags, including sub-arrays for <a href="http://ogp.me/" target="_new">OpenGraph</a> tags, <a href="https://dev.twitter.com/docs/cards/markup-reference" target="_new">Twitter Card</a> metadata, <a href="http://www.schema.org" target="_new">schema.org</a> microdata, and -- if available -- <a href="http://www.oembed.com" target="_new">oEmbed</a> metadata.</div></td>
-</tr>
-<tr>
-<td class=""><code>querystring</code></td>
-<td class=" optional"><div>Returns any key/value pairs present in the URL querystring. Items without a discrete value will be returned as <code>true</code>.</div></td>
-</tr>
-</table>
-<!--{endfields}-->
-<h3 id="discussion">Comment Extraction</h3>
-<p>By default the Article API will attempt to extract comments from article pages, using integrated functionality from the Diffbot Discussion API. Comment data will be returned in the <code>discussion</code> object (nested within the primary article object). The full syntax for discussion data is available in the <a href="api-discussion">Discussion API documentation</a>.</p>
+Discussion extraction can be disabled using the argument `discussion=false`. Note that if a page has recently been processed by Diffbot, cached comments may be returned even if `discussion=false` is passed.
 
-<p>Discussion extraction can be disabled using the argument <code>discussion=false</code>. Note that if a page has recently been processed by Diffbot, cached comments may be returned even if <code>discussion=false</code> is passed.</p>
+## Advanced Text Analysis Powered by Semantria
 
-<h3 id="semantria">Advanced Text Analysis Powered by Semantria</h3>
-<p></p>
-<div class="pull-right span3"><img src="/img/semantria.png"></div>Our <a href="guides-semantria">native integration with Semantria</a> optionally allows extracted article content to be fully processed for categorization, entity and keyword extraction, and sentiment analysis. See <a href="api-semantria">documentation</a> for information on how to integrate your Semantria account with Diffbot's Article API.
+<img src="/img/semantria.png" style="float:right;">Our [native integration with Semantria](guides-semantria.md) optionally allows extracted article content to be fully processed for categorization, entity and keyword extraction, and sentiment analysis. See [documentation](api-semantria.md) for information on how to integrate your Semantria account with Diffbot's Article API.
 
-<h3 id="sampleresponse">Example Response</h3>
-<p>The following request --</p>
-  
+## Example Response
 
-```text
-https://api.diffbot.com/v3/article?token=...&amp;url=http%3A%2F%2Fblog.diffbot.com%2Fdiffbots-new-product-api-teaches-robots-to-shop-online
+The following request --
+
+```plaintext
+https://api.diffbot.com/v3/article?token=...&url=http%3A%2F%2Fblog.diffbot.com%2Fdiffbots-new-product-api-teaches-robots-to-shop-online
 ```
+-- will result in this API response:
 
-
-<p>-- will result in this API response:</p>
-
-<!--{codesample1}-->
-
-```text
+```json
 {
   "request": {
     "pageUrl": "http://blog.diffbot.com/diffbots-new-product-api-teaches-robots-to-shop-online",
@@ -337,7 +147,7 @@ https://api.diffbot.com/v3/article?token=...&amp;url=http%3A%2F%2Fblog.diffbot.c
       "videos": [
         {
           "diffbotUri": "video|3|-576904516",
-          "url": "http://www.youtube.com/embed/lfcri5ungRo?version=3&amp;rel=1&amp;fs=1&amp;autohide=2&amp;showsearch=0&amp;showinfo=1&amp;iv_load_policy=1&amp;wmode=transparent",
+          "url": "http://www.youtube.com/embed/lfcri5ungRo?version=3&rel=1&fs=1&autohide=2&showsearch=0&showinfo=1&iv_load_policy=1&wmode=transparent",
           "primary": true
         }
       ],
@@ -385,7 +195,7 @@ https://api.diffbot.com/v3/article?token=...&amp;url=http%3A%2F%2Fblog.diffbot.c
       "humanLanguage": "en",
       "authorUrl": "http://blog.diffbot.com/author/johndavi/",
       "pageUrl": "http://blog.diffbot.com/diffbots-new-product-api-teaches-robots-to-shop-online",
-      "html": "&lt;p&gt;Diffbot&amp;rsquo;s human wranglers are proud today to announce the release of our newest product: an API for&amp;hellip; products!&lt;/p&gt;\n&lt;p&gt;The &lt;a href=\"http://www.diffbot.com/products/automatic/product\"&gt;Product API&lt;/a&gt; can be used for extracting clean, structured data from any e-commerce product page. It automatically makes available all the product data you&amp;rsquo;d expect: price, discount/savings amount, shipping cost, product description, any relevant product images, SKU and/or other product IDs.&lt;/p&gt;\n&lt;p&gt;Even cooler: pair the Product API with &lt;a href=\"http://www.diffbot.com/products/crawlbot\"&gt;Crawlbot&lt;/a&gt;, our intelligent site-spidering tool, and let Diffbot determine which pages are products, then automatically structure the entire catalog. Here&amp;rsquo;s a quick demonstration of Crawlbot at work:&lt;/p&gt;\n&lt;figure&gt;&lt;iframe frameborder=\"0\" src=\"http://www.youtube.com/embed/lfcri5ungRo?version=3&amp;rel=1&amp;fs=1&amp;autohide=2&amp;showsearch=0&amp;showinfo=1&amp;iv_load_policy=1&amp;wmode=transparent\"&gt;&lt;/iframe&gt;&lt;/figure&gt;\n&lt;p&gt;We&amp;rsquo;ve developed the Product API over the course of two years, building upon our core vision technology that&amp;rsquo;s extracted structured data from billions of web pages, and training our machine learning systems using data from tens of thousands of unique shopping sites. We can&amp;rsquo;t wait for you to try it out.&lt;/p&gt;\n&lt;p&gt;What are you waiting for? Check out the &lt;a href=\"http://www.diffbot.com/products/automatic/product\"&gt;Product API documentation&lt;/a&gt; and dive on in! If you need a token, check out our &lt;a href=\"http://www.diffbot.com/pricing\"&gt;pricing and plans&lt;/a&gt; (including our Free plan).&lt;/p&gt;\n&lt;p&gt;Questions? Hit us up at &lt;a href=\"mailto:support@diffbot.com\"&gt;support@diffbot.com&lt;/a&gt;.&lt;/p&gt;",
+      "html": "<p>Diffbot&rsquo;s human wranglers are proud today to announce the release of our newest product: an API for&hellip; products!</p>\n<p>The <a href=\"http://www.diffbot.com/products/automatic/product\">Product API</a> can be used for extracting clean, structured data from any e-commerce product page. It automatically makes available all the product data you&rsquo;d expect: price, discount/savings amount, shipping cost, product description, any relevant product images, SKU and/or other product IDs.</p>\n<p>Even cooler: pair the Product API with <a href=\"http://www.diffbot.com/products/crawlbot\">Crawlbot</a>, our intelligent site-spidering tool, and let Diffbot determine which pages are products, then automatically structure the entire catalog. Here&rsquo;s a quick demonstration of Crawlbot at work:</p>\n<figure><iframe frameborder=\"0\" src=\"http://www.youtube.com/embed/lfcri5ungRo?version=3&rel=1&fs=1&autohide=2&showsearch=0&showinfo=1&iv_load_policy=1&wmode=transparent\"></iframe></figure>\n<p>We&rsquo;ve developed the Product API over the course of two years, building upon our core vision technology that&rsquo;s extracted structured data from billions of web pages, and training our machine learning systems using data from tens of thousands of unique shopping sites. We can&rsquo;t wait for you to try it out.</p>\n<p>What are you waiting for? Check out the <a href=\"http://www.diffbot.com/products/automatic/product\">Product API documentation</a> and dive on in! If you need a token, check out our <a href=\"http://www.diffbot.com/pricing\">pricing and plans</a> (including our Free plan).</p>\n<p>Questions? Hit us up at <a href=\"mailto:support@diffbot.com\">support@diffbot.com</a>.</p>",
       "text": "Diffbot's human wranglers are proud today to announce the release of our newest product: an API for\u2026 products!\nThe Product API can be used for extracting clean, structured data from any e-commerce product page. It automatically makes available all the product data you'd expect: price, discount/savings amount, shipping cost, product description, any relevant product images, SKU and/or other product IDs.\nEven cooler: pair the Product API with Crawlbot, our intelligent site-spidering tool, and let Diffbot determine which pages are products, then automatically structure the entire catalog. Here's a quick demonstration of Crawlbot at work:\nWe've developed the Product API over the course of two years, building upon our core vision technology that's extracted structured data from billions of web pages, and training our machine learning systems using data from tens of thousands of unique shopping sites. We can't wait for you to try it out.\nWhat are you waiting for? Check out the Product API documentation and dive on in! If you need a token, check out our pricing and plans (including our Free plan).\nQuestions? Hit us up at support@diffbot.com.",
       "resolvedPageUrl": "http://blog.diffbot.com/diffbots-new-product-api-teaches-robots-to-shop-online/"
     }
@@ -393,49 +203,42 @@ https://api.diffbot.com/v3/article?token=...&amp;url=http%3A%2F%2Fblog.diffbot.c
 }
 ```
 
+## Authentication
 
-<!--{endcodesample1}-->
+You can supply Diffbot with basic authentication credentials or custom HTTP headers (see below) to access intranet pages or other sites that require a login.
 
-<h3 id="authenticating">Authentication</h3>
-<p>You can supply Diffbot with basic authentication credentials or custom HTTP headers (see below) to access intranet pages or other sites that require a login.</p>
+### Basic Authentication
 
-<h4>Basic Authentication</h4>
-<p>To access pages that require a login/password (using <a href="http://en.wikipedia.org/wiki/Basic_access_authentication" target="_blank">basic access authentication</a>), include the username and password in your <code>url</code> parameter, e.g.: <code>url=http%3A%2F%2FUSERNAME:PASSWORD@www.diffbot.com</code>.</p>
+To access pages that require a login/password (using [basic access authentication](https://en.wikipedia.org/wiki/Basic_access_authentication)), include the username and password in your `url` parameter, e.g.: `url=http%3A%2F%2FUSERNAME:PASSWORD@www.diffbot.com`.
 
-<h3 id="customheaders">Custom HTTP Headers</h3>
-<p>You can supply Diffbot APIs with custom HTTP headers that will be passed along when making requests to third-party sites. These can be used to define specific Referer, User-Agent, Cookie or any other values.</p>
-<p>Custom headers should be sent as HTTP headers in your request to <code>https://api.diffbot.com</code>, and prepended with <code>X-Forward-</code>.</p>
-<p>For instance, to send custom <code>User-Agent</code>, <code>Referer</code> and <code>My-Custom-Header</code> header values:</p>
-<table class="controls table table-bordered" border="0" cellpadding="5">
-<thead><tr>
-<th>Desired Header</th>
-<th>Send to api.diffbot.com</th>
-</tr></thead>
-<tbody>
-<tr>
-<td><code>User-Agent:Diffbot</code></td>
-<td><code>X-Forward-User-Agent:Diffbot</code></td>
-</tr>
-<tr>
-<td><code>Referer:diffbot.com</code></td>
-<td><code>X-Forward-Referer:diffbot.com</code></td>
-</tr>
-<tr>
-<td><code>My-Custom-Header:CustomValue</code></td>
-<td><code>X-Forward-My-Custom-Header:CustomValue</code></td>
-</tr>
-</tbody>
-</table>
+## Custom HTTP Headers
 
-<h3 id="x-evaluate">Custom Javascript</h3>
+You can supply Diffbot APIs with custom HTTP headers that will be passed along when making requests to third-party sites. These can be used to define specific Referer, User-Agent, Cookie or any other values.
+
+Custom headers should be sent as HTTP headers in your request to `https://api.diffbot.com`, and prepended with `X-Forward-`.
+
+For instance, to send custom `User-Agent`, `Referer` and `My-Custom-Header` header values:
+
+| Desired Header | Send to api.diffbot.com |
+| :-- | :-- |
+| `User-Agent:Diffbot` | `X-Forward-User-Agent:Diffbot` |
+| `Referer:diffbot.com` | `X-Forward-Referer:diffbot.com` |
+| `My-Custom-Header:CustomValue` | `X-Forward-My-Custom-Header:CustomValue` |
+
+## Custom Javascript
+
 <div class="alert">This functionality is currently in beta.</div>
-<p>Using the <code>X-Evaluate</code> custom header (sent as <code>X-Forward-X-Evaluate</code>), you can inject your own Javascript code into web pages. Custom Javascript will be executed once the DOM has loaded.</p>
-<p>Custom Javascript should be provided as a text string and contained in its own function. You must also include the special functions <code>start()</code> and <code>end()</code> to indicate the beginning and end of your custom script. Once <code>end()</code> fires, the updated document will be processed by your chosen extraction API.</p>
-<p>It's recommended that your <code>end()</code> function be offset using <code>setTimeout</code> (see <a href="http://www.w3schools.com/js/js_timing.asp" target="_blank">JavaScript Timing Events</a>) in order to accommodate your primary function processing. Additionally, if your custom Javascript requires access to Ajax-delivered content, it may be necessary to offset your entire function using <code>setTimeout</code> in order to delay the start of your processing.</p>
-<p>The following sample <code>X-Evaluate</code> header waits one-half second after the DOM has loaded, enacts a click on the <code>a.loadMore</code> element, then waits 800 milliseconds before signaling the <code>end()</code>:</p>
+
+Using the `X-Evaluate` custom header (sent as `X-Forward-X-Evaluate`), you can inject your own Javascript code into web pages. Custom Javascript will be executed once the DOM has loaded.
+
+Custom Javascript should be provided as a text string and contained in its own function. You must also include the special functions `start()` and `end()` to indicate the beginning and end of your custom script. Once `end()` fires, the updated document will be processed by your chosen extraction API.
+
+It's recommended that your `end()` function be offset using `setTimeout` (see [JavaScript Timing Events](https://www.w3schools.com/js/js_timing.asp)) in order to accommodate your primary function processing. Additionally, if your custom Javascript requires access to Ajax-delivered content, it may be necessary to offset your entire function using `setTimeout` in order to delay the start of your processing.
+
+The following sample `X-Evaluate` header waits one-half second after the DOM has loaded, enacts a click on the `a.loadMore` element, then waits 800 milliseconds before signaling the `end()`:
 
 
-```text
+```js
 function() {
     start();
     setTimeout(function() {
@@ -452,44 +255,32 @@ function() {
 }
 ```
 
+Delivered as a string value as a custom header:
 
-
-<p>Delivered as a string value as a custom header:</p>
-
-
-```text
+```json
 "X-Forward-X-Evaluate": "function() {start();setTimeout(function(){var loadMoreNode=document.querySelector('a.loadMore');if (loadMoreNode != null) {loadMoreNode.click();setTimeout(function(){end();}, 800);} else {end();}},500);}"
 ```
 
+## Posting Content
 
+If your content is not publicly available (e.g., behind a firewall), you can POST markup or plain text directly to the Article API endpoint for analysis:
 
-<h3 id="posting">Posting Content</h3>
-<p>If your content is not publicly available (e.g., behind a firewall), you can POST markup or plain text directly to the Article API endpoint for analysis:
-</p>
-
-
-```text
-https://api.diffbot.com/v3/article?token=...&amp;url=...
+```plaintext
+https://api.diffbot.com/v3/article?token=...&url=...
 ```
 
+Please note that if you submit HTML, the `url` argument is still required, and will be used to resolve any relative links contained in the markup.
 
-<p>Please note that if you submit HTML, the <code>url</code> argument is still required, and will be used to resolve any relative links contained in the markup.</p>
-<p>Provide the content to analyze as your POST body, and specify the <code>Content-Type</code> header as <code>text/html</code> (for full markup) or <code>text/plain</code> (for text-only).</p>
-<p><strong>HTML Post Sample</strong>:</p>
-  
+Provide the content to analyze as your POST body, and specify the `Content-Type` header as `text/html` (for full markup) or `text/plain` (for text-only).
 
-```text
-curl -H "Content-Type: text/html" -d '&lt;html&gt;&lt;body&gt;&lt;p&gt;Now is the time for all good robots to come to the aid of their-- oh never mind, run!&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;' 'https://api.diffbot.com/v3/article?token=...&amp;url=http%3A%2F%2Fblog.diffbot.com'
+### HTML Post Sample
+
+```plaintext
+curl -H "Content-Type: text/html" -d '<html><body><p>Now is the time for all good robots to come to the aid of their-- oh never mind, run!</p></body></html>' 'https://api.diffbot.com/v3/article?token=...&url=http%3A%2F%2Fblog.diffbot.com'
 ```
 
+### Plaintext Post Sample
 
-<p><strong>Plaintext Post Sample</strong>:</p>
-  
-
-```text
-curl -H "Content-Type: text/plain" -d 'Now is the time for all good robots to come to the aid of their-- oh never mind, run!' 'https://api.diffbot.com/v3/article?token=...&amp;fields=tags,text'
+```plaintext
+curl -H "Content-Type: text/plain" -d 'Now is the time for all good robots to come to the aid of their-- oh never mind, run!' 'https://api.diffbot.com/v3/article?token=...&fields=tags,text'
 ```
-
-
-
-</div>

--- a/docs/api-bulk.md
+++ b/docs/api-bulk.md
@@ -5,192 +5,92 @@ sidebar_label: Bulk API
 todo: Modify links to old API docs
 ---
 
-<div id="docBody">
-<p>The Bulk API allows you to submit large numbers of URLs for Diffbot API processing. It is built atop the <a href="guides-crawl">Crawlbot</a> API and shares much of the same underlying model. Both APIs return data in JSON format.</p>
-<h3 id="creating">Creating a Bulk Job</h3>
-<div class="indent">
-<p>To create a bulk job, make a POST request to <code>https://api.diffbot.com/v3/bulk</code>.</p>
-<p>Set your <code>Content-Type</code> header to <code>application/x-www-form-urlencoded</code> (not <code>multipart/form-data</code>). POST body content should be in querystring format (key/value pairs), e.g.:</p>
-  
+The Bulk API allows you to submit large numbers of URLs for Diffbot API processing. It is built atop the [Crawlbot](guides-crawl.md) API and shares much of the same underlying model. Both APIs return data in JSON format.
 
-```text
-<code>name=bulkTest&amp;token=sampletoken&amp;urls=http://www.diffbot.com http://blog.diffbot.com&amp;apiUrl=https://api.diffbot.com/v3/analyze</code>
+## Creating a Bulk Job
+
+To create a bulk job, make a POST request to `https://api.diffbot.com/v3/bulk`.
+
+Set your `Content-Type` header to `application/x-www-form-urlencoded` (not `multipart/form-data`). POST body content should be in querystring format (key/value pairs), e.g.:
+
+```plaintext
+name=bulkTest&token=sampletoken&urls=https://www.diffbot.com https://blog.diffbot.com&apiUrl=https://api.diffbot.com/v3/analyze
 ```
 
+Your POST body should contain the following fields:
 
+| Argument | Description |
+| :------- | :---------- |
+| `token` | Developer [token](https://www.diffbot.com/pricing) |
+| `name` | Job name. This should be a unique identifier and will be used to modify your bulk job and retrieve its output. |
+| `urls` | Space-delimited list of URLs to process. If you are on the Startup plan, jobs must contain at least 50 URLs. |
+| `apiUrl` | The full Diffbot API to be used for each URL. For instance, to process each URL via the article API, supply `https://api.diffbot.com/v3/article`. You may also include API parameters, e.g. `https://api.diffbot.com/v3/article?fields=meta,tags`. </td></tr><td colspan="2">**Optional arguments**</td> |
+| `customHeaders` | Set custom headers to be used for processing each URL. Send multiple `customHeaders` values in your POST body, with header keys/values delimited by a colon (and URL-encoded). [See more information on using this functionality](guides-custom-headers.md). |
+| `notifyEmail` | Send a message to this email address when the bulk job completes. |
+| `notifyWebhook` | Pass a URL to be notified when the bulk job completes. You will receive a POST with the full [JSON response](#response) in the POST body. |
+| `obeyRobots` | Pass `obeyRobots=0` to ignore a site's robots.txt instructions. [See more](explain-robots-txt.md). |
+| `repeat` | Specify the number of days as a floating-point (e.g. `repeat=7.0`) to repeat this job. By default bulk jobs will not be repeated. |
+| `maxRounds` | Specify the maximum number of repeats. Use `maxRounds=-1` to continually repeat. |
+| `pageProcessPattern` | Enter &#124;&#124;-separated strings to limit pages processed to those whose HTML contains *any* of the content strings. If a page does not contain at least one of the strings, it will be ignored. |
 
-<p>Your POST body should contain the following fields:</p>
+### Response
 
-<table class="controls table table-bordered" border="0" cellpadding="5">
-<thead><tr>
-<th>Argument</th>
-<th>Description</th>
-</tr></thead>
-<tbody>
-<tr>
-<td><code>token</code></td>
-<td>Developer <a href="https://diffbot.com/pricing">token</a>
-</td>
-</tr>
-<tr>
-<td><code>name</code></td>
-<td>Job name. This should be a unique identifier and will be used to modify your bulk job and retrieve its output.</td>
-</tr>
-<tr>
-<td><code>urls</code></td>
-<td>Space-delimited list of URLs to process. If you are on the Startup plan, jobs must contain at least 50 URLs.</td>
-</tr>
-<tr>
-<td><code>apiUrl</code></td>
-<td>The full Diffbot API to be used for each URL. For instance, to process each URL via the article API, supply <code>https://api.diffbot.com/v3/article</code>. You may also include API parameters, e.g. <code>https://api.diffbot.com/v3/article?fields=meta,tags</code>.</td>
-</tr>
+Upon adding a new bulk job, you will receive a success message in the JSON response, in addition to full job details:
 
-<tr><td colspan="2"><strong>Optional Arguments</strong></td></tr>
-<tr>
-<td><code>customHeaders</code></td>
-<td>Set custom headers to be used for processing each URL. Send multiple <code>customHeaders</code> values in your POST body, with header keys/values delimited by a colon (and URL-encoded). <a href="guides-custom-headers">See more information on using this functionality</a>.</td>
-</tr>
-<tr>
-<td><code>notifyEmail</code></td>
-<td>Send a message to this email address when the bulk job completes.</td>
-</tr>
-<tr>
-<td><code>notifyWebhook</code></td>
-<td>Pass a URL to be notified when the bulk job completes. You will receive a POST with the full <a href="#response">JSON response</a> in the POST body.</td>
-</tr>
-<!--  <tr><td><code>obeyRobots</code></td><td>Pass <code>obeyRobots=0</code> to ignore a site's robots.txt instructions.</td></tr> -->
-<tr>
-<td><code>repeat</code></td>
-<td>Specify the number of days as a floating-point (e.g. <code>repeat=7.0</code>) to repeat this job. By default bulk jobs will not be repeated.</td>
-</tr>
-<tr>
-<td><code>maxRounds</code></td>
-<td>Specify the maximum number of repeats. Use <code>maxRounds=-1</code> to continually repeat.</td>
-</tr>
-<tr>
-<td><code>pageProcessPattern</code></td>
-<td>Enter ||-separated strings to limit pages processed to those whose HTML contains <em>any</em> of the content strings. If a page does not contain at least one of the strings, it will be ignored.</td>
-</tr>
-</tbody>
-</table>
-
-<h4 id="response">Response</h4>
-<p>Upon adding a new bulk job, you will receive a success message in the JSON response, in addition to full job details:</p>
-
-
-```text
-
-  "response": "Successfully added urls for spidering."
-
+```json
+"response": "Successfully added urls for spidering."
 ```
 
+## Pausing, Deleting or Restarting Bulk Jobs
 
+You can manage your bulk jobs by making GET requests to the same endpoint, `https://api.diffbot.com/v3/bulk`.
 
-<hr>
+Provide the following data:
 
-<h3 id="pausedelete">Pausing, Deleting or Restarting Bulk Jobs</h3>
-<p>You can manage your bulk jobs by making GET requests to the same endpoint, <code>https://api.diffbot.com/v3/bulk</code>.</p>
-<p>Provide the following data:</p>
+| Argument | Description |
+| :------- | :---------- |
+| `token` | Developer [token](https://www.diffbot.com/pricing) |
+| `name` | Job name as defined when the bulk was created. |
+| `pause` | Pass `pause=1` to pause a bulk job. Pass `pause=0` to resume a paused job. |
+| `restart` | Pass `restart=1` to restart a bulk job. This will erase all processed data and re-process all of the submitted URLs. |
+| `delete` | Pass `delete=1` to delete a job, and all associated data, completely. |
 
-<table class="controls table table-bordered" border="0" cellpadding="5">
-<thead><tr>
-<th>Parameter</th>
-<th>Description</th>
-</tr></thead>
-<tbody>
-<tr>
-<td><code>token</code></td>
-<td>Developer <a href="https://diffbot.com/pricing">token</a>
-</td>
-</tr>
-<tr>
-<td><code>name</code></td>
-<td>Job name as defined when the bulk was created.</td>
-</tr>
-<tr>
-<td><code>pause</code></td>
-<td>Pass <code>pause=1</code> to pause a bulk job. Pass <code>pause=0</code> to resume a paused job.</td>
-</tr>
-<tr>
-<td><code>restart</code></td>
-<td>Pass <code>restart=1</code> to restart a bulk job. This will erase all processed data and re-process all of the submitted URLs.</td>
-</tr>
-<tr>
-<td><code>delete</code></td>
-<td>Pass <code>delete=1</code> to delete a job, and all associated data, completely.</td>
-</tr>
-</tbody>
-</table>
+## Retrieving Bulk Job Data
 
-<hr>
+To download results please make a GET request to `https://api.diffbot.com/v3/bulk/data`. Provide the following arguments based on the data you need. By default the complete extracted JSON data will be downloaded.
 
-<h3 id="retrieving">Retrieving Bulk Job Data</h3>
-<p>To download results please make a GET request to <code>https://api.diffbot.com/v3/bulk/data</code>. Provide the following arguments based on the data you need. By default the complete extracted JSON data will be downloaded.</p>
-<table class="controls table table-bordered" border="0" cellpadding="5">
-<thead><tr>
-<th>Parameter</th>
-<th>Description</th>
-</tr></thead>
-<tbody>
-<tr>
-<td><code>token</code></td>
-<td>Diffbot token.</td>
-</tr>
-<tr>
-<td><code>name</code></td>
-<td>Name of the bulk job whose data you wish to download.</td>
-</tr>
-<tr>
-<td><code>format</code></td>
-<td>Request <code>format=csv</code> to download the extracted data in CSV format (default: <code>json</code>). Note that CSV files will only contain top-level fields.</td>
-</tr>
-<tr><td colspan="2"><strong>For diagnostic data:</strong></td></tr>
-<tr>
-<td><code>type</code></td>
-<td>Request <code>type=urls</code> to retrieve the bulk <a href="explain-bulk-url-report">URL Report</a> (CSV).</td>
-</tr>
-<tr>
-<td><code>num</code></td>
-<td>Pass an integer value (e.g. <code>num=100</code>) to request a subset of URLs, most recently processed first.</td>
-</tr>
-</tbody>
-</table>
-<h3>Using the Search API to Retrieve Bulk Job Data</h3>
-<p>You can also use Diffbot's <a href="api-search">Search API</a> to fine-tune the data retrieved from your Crawlbot or Bulk API jobs.</p>
-<p><a href="api-search">Search API documentation</a></p>
-<hr>
+| Argument | Description |
+| :------- | :---------- |
+| `token` | Developer [token](https://www.diffbot.com/pricing) |
+| `name` | Name of the bulk job whose data you wish to download. |
+| `format` | Request `format=csv` to download the extracted data in CSV format (default: `json`). Note that CSV files will only contain top-level fields. </td></tr><td colspan="2">**For diagnostic data:**</td> |
+| `type` | Request `type=urls` to retrieve the bulk [URL Report](explain-bulk-url-report.md) (CSV). |
+| `num` | Pass an integer value (e.g. `num=100`) to request a subset of URLs, most recently processed first. |
 
+## Using the Search API to Retrieve Bulk Job Data
 
-<h3 id="details">Viewing Bulk Job Details</h3>
-<p>Your active bulk jobs (along with any Crawlbot crawls) will be returned in the <code>jobs</code> object in a request made to <code>https://api.diffbot.com/v3/bulk</code>.</p>
-<p>To retrieve a single job's details, provide the job's <code>name</code> in your request:</p>
-<table class="controls table table-bordered" border="0" cellpadding="5">
-<thead><tr>
-<th>Parameter</th>
-<th>Description</th>
-</tr></thead>
-<tbody>
-<tr>
-<td><code>token</code></td>
-<td>Developer <a href="https://diffbot.com/pricing">token</a>
-</td>
-</tr>
-<tr>
-<td><code>name</code></td>
-<td>Name of bulk job (or crawl) to retrieve.</td>
-</tr>
-</tbody>
-</table>
+You can also use Diffbot's [Search API](api-search.md) to fine-tune the data retrieved from your Crawlbot or Bulk API jobs.
 
-<p>To view all bulk jobs (and crawls), simply omit the <code>name</code> parameter: <code>https://api.diffbot.com/v3/bulk?token={{token}}</code></p>
+[Search API documentation](api-search.md)
 
-<h4>
-<a name="response"></a>Response</h4>
-<p>This will return a JSON response of your token's Bulk API jobs (and crawls). Sample response from a single job:</p>
+## Viewing Bulk Job Details
 
-<!--{codesample1}-->
+Your active bulk jobs (along with any Crawlbot crawls) will be returned in the `jobs` object in a request made to `https://api.diffbot.com/v3/bulk`.
 
-```text
+To retrieve a single job's details, provide the job's `name` in your request:
+
+| Argument | Description |
+| :------- | :---------- |
+| `token` | Developer [token](https://www.diffbot.com/pricing) |
+| `name` | Name of bulk job (or crawl) to retrieve. |
+
+To view all bulk jobs (and crawls), simply omit the `name` parameter: `https://api.diffbot.com/v3/bulk?token={{token}}`
+
+### Response
+
+This will return a JSON response of your token's Bulk API jobs (and crawls). Sample response from a single job:
+
+```json
 {
   "jobs": [
     {
@@ -235,49 +135,21 @@ todo: Modify links to old API docs
 }
 ```
 
+## Status Codes
 
-<!--{endcodesample1}-->
-<h3 id="status">Status Codes</h3>
-<p>The <code>jobStatus</code> object will return the following status codes and associated messages:</p>
+The `jobStatus` object will return the following status codes and associated messages:
 
-<table class="controls table table-bordered table-condensed" border="0" cellpadding="5">
-<thead><tr>
-<th>Status</th>
-<th>Message</th>
-</tr></thead>
-<tbody>
-<tr>
-<td>0</td>
-<td>Job is initializing</td>
-</tr>
+| Status | Message |
+| :----- | :------ |
+| 0 | Job is initializing |
+| 6 | Job paused |
+| 7 | Job in progress |
+| 8 | All crawling temporarily paused by root administrator for maintenance. |
+| 9 | Job has completed and no repeat is scheduled |
+
+
 <!--<tr><td>1</td><td>Job has reached maxRounds limit</td></tr>
 <tr><td>2</td><td>Job has reached maxToCrawl limit</td></tr>
 <tr><td>3</td><td>Job has reached maxToProcess limit</td></tr>
 <tr><td>4</td><td>Next round to start in _____ seconds</td></tr>
 <tr><td>5</td><td>No URLs were added to the crawl</td></tr>-->
-<tr>
-<td>6</td>
-<td>Job paused</td>
-</tr>
-<tr>
-<td>7</td>
-<td>Job in progress</td>
-</tr>
-<tr>
-<td>8</td>
-<td>All crawling temporarily paused by root administrator for maintenance.</td>
-</tr>
-<tr>
-<td>9</td>
-<td>Job has completed and no repeat is scheduled</td>
-</tr>
-</tbody>
-</table>
-
-
-
-</div>
-
-
-
-</div>

--- a/docs/api-crawlbot-api.md
+++ b/docs/api-crawlbot-api.md
@@ -6,303 +6,146 @@ todo: Modify links to old Dashboard
 todo: Modify links to old API docs
 ---
 
-<div id="docBody">
-<p>The Crawlbot API allows you to programmatically manage <a href="/dev/crawl">Crawlbot</a> crawls and retrieve output. Crawlbot API responses are in JSON format.</p>
+The Crawlbot API allows you to programmatically manage <a href="/dev/crawl">Crawlbot</a> crawls and retrieve output. Crawlbot API responses are in JSON format.
 
-<h3 id="creating">Creating or Updating a Crawl</h3>
-<p><b>Note that the limit of active crawls on a single token is 1000. More information <a href="error-too-many-collections">here</a>.</b></p>
-<div class="indent">
-<p>To create a crawl, make a POST request to <code>https://api.diffbot.com/v3/crawl</code>.</p>
-<p>Provide the following data:</p>
-<table class="controls table table-bordered" border="0" cellpadding="5">
-<thead><tr>
-<th>Parameter</th>
-<th>Description</th>
-</tr></thead>
-<tbody>
-<tr>
-<td><code>token</code></td>
-<td>Developer <a href="https://diffbot.com/pricing">token</a>
-</td>
-</tr>
-<tr>
-<td><code>name</code></td>
-<td>Job name. This should be a unique identifier and can be used to modify your crawl or retrieve its output.</td>
-</tr>
-<tr>
-<td><code>seeds</code></td>
-<td>Seed URL(s). Must be <a href="http://en.wikipedia.org/wiki/Percent-encoding" target="_blank">URL encoded</a>. Separate multiple URLs with whitespace to spider multiple sites within the same crawl. If the seed contains a non-www subdomain ("http://blog.diffbot.com" or "http://support.diffbot.com") Crawlbot will restrict spidering to the specified <strong>subdomain</strong>.</td>
-</tr>
-<tr>
-<td><code>apiUrl</code></td>
-<td>Full Diffbot API URL through which to process pages. E.g., <code>&amp;apiUrl=https://api.diffbot.com/v3/article</code> to process matching links via the <a href="https://diffbot.comhttp://www.diffbot.com/products/automatic/article">Article API</a>. The Diffbot API URL can include querystring parameters to tailor the output. For example, <code>&amp;apiUrl=https://api.diffbot.com/v3/product?fields=querystring,meta</code> will process matching links using the <a href="https://diffbot.comhttp://www.diffbot.com/products/automatic/product">Product API</a>, and also return the <code>querystring</code> and <code>meta</code> fields.
-<br><br>
-  To automatically identify and process content using our <a href="https://diffbot.com/products/automatic/analyze">Analyze API</a> (Smart Processing), pass <code>apiUrl=https://api.diffbot.com/v3/analyze?mode=auto</code> to return all page-types. See full Analyze API documentation under the <a href="/dev/docs">Automatic APIs documentation</a>.
-<br><br>
-  Be sure to <a href="http://en.wikipedia.org/wiki/Percent-encoding" target="_blank">URL encode</a> your Diffbot API actions.</td>
-</tr>
-</tbody>
-</table>
-<p>You can refine your crawl using the following optional controls. <a href="explain-crawling-versus-processing">Read more on crawling versus processing</a>.</p>
-<table class="controls table table-bordered" border="0" cellpadding="5">
-<thead><tr>
-<th>Parameter</th>
-<th>Description</th>
-</tr></thead>
-<tbody>
-<tr>
-<td><code>urlCrawlPattern</code></td>
-<td>Specify ||-separated <strong>strings</strong> to limit pages crawled to those whose URLs contain <em>any</em> of the content strings. You can use the exclamation point to specify a negative string, e.g. <code>!product</code> to exclude URLs containing the string "product," and the <code>^</code> and <code>$</code> characters to limit matches to the beginning or end of the URL.<br><br>The use of a <code>urlCrawlPattern</code> will allow Crawlbot to spider outside of the seed domain; it will follow all matching URLs regardless of domain.</td>
-</tr>
-<tr>
-<td><code>urlCrawlRegEx</code></td>
-<td>Specify a regular expression to limit pages <strong>crawled</strong> to those URLs that contain a match to your expression. This will override any <code>urlCrawlPattern</code> value.</td>
-</tr>
-<tr>
-<td><code>urlProcessPattern</code></td>
-<td>Specify ||-separated <strong>strings</strong> to limit pages processed to those whose URLs contain <em>any</em> of the content strings. You can use the exclamation point to specify a negative string, e.g. <code>!/category</code> to exclude URLs containing the string "/category," and the <code>^</code> and <code>$</code> characters to limit matches to the beginning or end of the URL.</td>
-</tr>
-<tr>
-<td><code>urlProcessRegEx</code></td>
-<td>Specify a regular expression to limit pages <strong>processed</strong> to those URLs that contain a match to your expression. This will override any <code>urlProcessPattern</code> value.</td>
-</tr>
-<tr>
-<td><code>pageProcessPattern</code></td>
-<td>Specify ||-separated strings to limit pages <strong>processed</strong> to those whose HTML contains <em>any</em> of the content strings.</td>
-</tr>
-</tbody>
-</table>
-<p>Additional (optional) Parameters:</p>
-<table class="controls table table-bordered" border="0" cellpadding="5">
-<thead><tr>
-<th>Parameter</th>
-<th>Description</th>
-</tr></thead>
-<tbody>
-<tr>
-<td><code>customHeaders</code></td>
-<td>Set multiple custom headers to be used while crawling and processing pages sent to Diffbot APIs. Each header should be sent in its own <code>customHeaders</code> argument, with a colon delimiting the header name and value, and should be URL-encoded. For example, <code>&amp;customHeaders=Accept-Language%3Aen-us</code>. <a href="guides-custom-headers">See more information on using this functionality</a>.</td>
-</tr>
-<tr>
-<td><code>useCanonical</code></td>
-<td>Pass <code>useCanonical=0</code> to disable deduplication of pages based on a canonical link definition. <a href="explain-page-deduplication">See more</a>.</td>
-</tr>
-<tr>
-<td><code>obeyRobots</code></td>
-<td>Pass <code>obeyRobots=0</code> to ignore a site's robots.txt instructions. <a href="explain-robots-txt">See more</a>.</td>
-</tr>
-<tr>
-<td><code>restrictDomain</code></td>
-<td>Pass <code>restrictDomain=0</code> to allow limited crawling across subdomains/domains. <a href="guides-restrict-domain">See more</a>.</td>
-</tr>
-<tr>
-<td><code>useProxies</code></td>
-<td>Set value to <code>1</code> to force the use of proxy IPs for the crawl. This will utilize proxy servers for both crawling and processing of pages.</td>
-</tr>
-<tr>
-<td><code>maxHops</code></td>
-<td>Specify the depth of your crawl. A <code>maxHops=0</code> will limit <strong>processing</strong> to the seed URL(s) only -- no other links will be processed; <code>maxHops=1</code> will process all (otherwise matching) pages whose links appear on seed URL(s); <code>maxHops=2</code> will process pages whose links appear on those pages; and so on.<br><br>By default (<code>maxHops=-1</code>) Crawlbot will crawl and process links at any depth.</td>
-</tr>
-<tr>
-<td><code>maxToCrawl</code></td>
-<td>Specify max pages to spider. Default: 100,000.</td>
-</tr>
-<tr>
-<td><code>maxToProcess</code></td>
-<td>Specify max pages to process through Diffbot APIs. Default: 100,000.</td>
-</tr>
-<tr>
-<td><code>maxToCrawlPerSubdomain</code></td>
-<td>Specify max pages to spider per subdomain. Default: no limit (-1)</td>
-</tr>
-<tr>
-<td><code>maxToProcessPerSubdomain</code></td>
-<td>Specify max pages to process per subdomain. Default: no limit (-1)</td>
-</tr>
-<tr>
-<td><code>notifyEmail</code></td>
-<td>Send a message to this email address when the crawl hits the <code>maxToCrawl</code> or <code>maxToProcess</code> limit, or when the crawl completes.</td>
-</tr>
-<tr>
-<td><code>notifyWebhook</code></td>
-<td>Pass a URL to be notified when the crawl hits the <code>maxToCrawl</code> or <code>maxToProcess</code> limit, or when the crawl completes. You will receive a POST with <code>X-Crawl-Name</code> and <code>X-Crawl-Status</code> in the headers, and the job's <a href="#response">JSON metadata</a> in the POST body. Note that in webhook POSTs the parent <code>jobs</code> will not be sent—only the individual job object will be returned.<br><br>We've integrated with Zapier to make webhooks even more powerful; <a href="guides-zapier">read more</a> on what you can do with Zapier and Diffbot.</td>
-</tr>
-<tr>
-<td><code>crawlDelay</code></td>
-<td>Wait this many seconds between each URL crawled from a single IP address. Specify the number of seconds as an integer or floating-point number (e.g., <code>crawlDelay=0.25</code>).</td>
-</tr>
-<tr>
-<td><code>repeat</code></td>
-<td>Specify the number of days as a floating-point (e.g. <code>repeat=7.0</code>) to repeat this crawl. By default crawls will not be repeated.</td>
-</tr>
-<tr>
-<td><code>seedRecrawlFrequency</code></td>
-<td>Useful for specifying a frequency, in number of days, to recrawl seed urls, which is independent of the overall recrawl frequency given by <code>repeat</code>. Defaults to <code>seedRecrawlFrequency=-1</code> to use the default frequency.</td>
-</tr>
-<tr>
-<td><code>onlyProcessIfNew</code></td>
-<td>By default repeat crawls will only process new (previously unprocessed) pages. Set to 0 (<code>onlyProcessIfNew=0</code>) to process all content on repeat crawls.</td>
-</tr>
-<tr>
-<td><code>maxRounds</code></td>
-<td>Specify the maximum number of crawl repeats. By default (<code>maxRounds=0</code>) repeating crawls will continue indefinitely.</td>
-</tr>
-</tbody>
-</table>
+## Creating or Updating a Crawl
+
+**Note that the limit of active crawls on a single token is 1000. More information [here](error-too-many-collections.md).**
+
+To create a crawl, make a POST request to `https://api.diffbot.com/v3/crawl`.
+
+Provide the following data:
+
+| Argument | Description |
+| :------- | :---------- |
+| `token` | Developer [token](https://www.diffbot.com/pricing). |
+| `name` | Job name. This should be a unique identifier and can be used to modify your crawl or retrieve its output. |
+| `seeds` | Seed URL(s). Must be [URL encoded](https://en.wikipedia.org/wiki/Percent-encoding). Separate multiple URLs with whitespace to spider multiple sites within the same crawl. If the seed contains a non-www subdomain ("https://blog.diffbot.com" or "https://support.diffbot.com") Crawlbot will restrict spidering to the specified **subdomain**. |
+| `apiUrl` | Full Diffbot API URL through which to process pages. E.g., `&apiUrl=https://api.diffbot.com/v3/article` to process matching links via the [Article API](https://www.diffbot.com/products/automatic/article). The Diffbot API URL can include querystring parameters to tailor the output. For example, `&apiUrl=https://api.diffbot.com/v3/product?fields=querystring,meta` will process matching links using the [Product API](https://www.diffbot.com/products/automatic/product), and also return the `querystring` and `meta` fields.<br><br>To automatically identify and process content using our [Analyze API](https://www.diffbot.com/products/automatic/analyze) (Smart Processing), pass `apiUrl=https://api.diffbot.com/v3/analyze?mode=auto` to return all page-types. See full Analyze API documentation under the <a href="/dev/docs">Automatic APIs documentation</a>.<br><br>Be sure to [URL encode](https://en.wikipedia.org/wiki/Percent-encoding) your Diffbot API actions. |
+
+You can refine your crawl using the following optional controls. [Read more on crawling versus processing](explain-crawling-versus-processing.md).
+
+| Argument | Description |
+| :------- | :---------- |
+| `urlCrawlPattern` | Specify &#124;&#124;-separated **strings** to limit pages crawled to those whose URLs contain *any* of the content strings. You can use the exclamation point to specify a negative string, e.g. `!product` to exclude URLs containing the string "product," and the `^` and `$` characters to limit matches to the beginning or end of the URL.<br><br>The use of a `urlCrawlPattern` will allow Crawlbot to spider outside of the seed domain; it will follow all matching URLs regardless of domain. |
+| `urlCrawlRegEx` | Specify a regular expression to limit pages **crawled** to those URLs that contain a match to your expression. This will override any `urlCrawlPattern` value. |
+| `urlProcessPattern` | Specify &#124;&#124;-separated **strings** to limit pages processed to those whose URLs contain *any* of the content strings. You can use the exclamation point to specify a negative string, e.g. `!/category` to exclude URLs containing the string "/category," and the `^` and `$` characters to limit matches to the beginning or end of the URL. |
+| `urlProcessRegEx` | Specify a regular expression to limit pages **processed** to those URLs that contain a match to your expression. This will override any `urlProcessPattern` value. |
+| `pageProcessPattern` | Specify &#124;&#124;-separated strings to limit pages **processed** to those whose HTML contains *any* of the content strings. |
+
+Additional (optional) Parameters:
+
+| Argument | Description |
+| :------- | :---------- |
+| `customHeaders` | Set multiple custom headers to be used while crawling and processing pages sent to Diffbot APIs. Each header should be sent in its own `customHeaders` argument, with a colon delimiting the header name and value, and should be URL-encoded. For example, `&customHeaders=Accept-Language%3Aen-us`. [See more information on using this functionality](guides-custom-headers.md). |
+| `useCanonical` | Pass `useCanonical=0` to disable deduplication of pages based on a canonical link definition. [See more](explain-page-deduplication.md). |
+| `obeyRobots` | Pass `obeyRobots=0` to ignore a site's robots.txt instructions. [See more](explain-robots-txt.md). |
+| `restrictDomain` | Pass `restrictDomain=0` to allow limited crawling across subdomains/domains. [See more](guides-restrict-domain.md). |
+| `useProxies` | Set value to `1` to force the use of proxy IPs for the crawl. This will utilize proxy servers for both crawling and processing of pages. |
+| `maxHops` | Specify the depth of your crawl. A `maxHops=0` will limit **processing** to the seed URL(s) only -- no other links will be processed; `maxHops=1` will process all (otherwise matching) pages whose links appear on seed URL(s); `maxHops=2` will process pages whose links appear on those pages; and so on.<br><br>By default (`maxHops=-1`) Crawlbot will crawl and process links at any depth. |
+| `maxToCrawl` | Specify max pages to spider. Default: 100,000. |
+| `maxToProcess` | Specify max pages to process through Diffbot APIs. Default: 100,000. |
+| `maxToCrawlPerSubdomain` | Specify max pages to spider per subdomain. Default: no limit (-1) |
+| `maxToProcessPerSubdomain` | Specify max pages to process per subdomain. Default: no limit (-1) |
+| `notifyEmail` | Send a message to this email address when the crawl hits the `maxToCrawl` or `maxToProcess` limit, or when the crawl completes. |
+| `notifyWebhook` | Pass a URL to be notified when the crawl hits the `maxToCrawl` or `maxToProcess` limit, or when the crawl completes. You will receive a POST with `X-Crawl-Name` and `X-Crawl-Status` in the headers, and the job's [JSON metadata](#json-metadata) in the POST body. Note that in webhook POSTs the parent `jobs` will not be sent—only the individual job object will be returned.<br><br>We've integrated with Zapier to make webhooks even more powerful; [read more](guides-zapier.md) on what you can do with Zapier and Diffbot. |
+| `crawlDelay` | Wait this many seconds between each URL crawled from a single IP address. Specify the number of seconds as an integer or floating-point number (e.g., `crawlDelay=0.25`). |
+| `repeat` | Specify the number of days as a floating-point (e.g. `repeat=7.0`) to repeat this crawl. By default crawls will not be repeated. |
+| `seedRecrawlFrequency` | Useful for specifying a frequency, in number of days, to recrawl seed urls, which is independent of the overall recrawl frequency given by `repeat`. Defaults to `seedRecrawlFrequency=-1` to use the default frequency. |
+| `onlyProcessIfNew` | By default repeat crawls will only process new (previously unprocessed) pages. Set to 0 (`onlyProcessIfNew=0`) to process all content on repeat crawls. |
+| `maxRounds` | Specify the maximum number of crawl repeats. By default (`maxRounds=0`) repeating crawls will continue indefinitely. |
+
 <!--
 <h4><a name="filterExpressions"></a>URL Filter Expressions</h4>
-<p>Crawlbot 2.0 features a powerful URL filtering engine allowing you to process URLs via myriad Diffbot APIs. You may pass multiple filters in each crawl. Each filter consists of an <code>expression</code> (the content to match) and an <code>action</code> (the processing or crawling action to take).</p>
+<p>Crawlbot 2.0 features a powerful URL filtering engine allowing you to process URLs via myriad Diffbot APIs. You may pass multiple filters in each crawl. Each filter consists of an `expression` (the content to match) and an `action` (the processing or crawling action to take).</p>
 <p>Filters are processed in the order in which they are sent in the querystring. URLs can only match a single filter.</p>
 <table class="controls table table-bordered" border="0" cellpadding="5">
 <tbody>
-<tr><td colspan="2"><strong>Expression options</strong></td></tr>
-<tr><td><code>expression=*</code></td><td>Matches all (remaining) pages. If this is the first filter expression it will match all pages.</td></tr>
-<tr><td><code>expression=<em>string</em></code></td><td>Matches all (remaining) URLs containing the text string.</td></tr>
-<tr><td><code>expression=^<em>string</em></code></td><td>Matches all (remaining) URLs starting with the text string.</td></tr>
-<tr><td><code>expression=$<em>string</em></code></td><td>Matches all (remaining) URLs ending with the text string.</td></tr>
+<tr><td colspan="2">**Expression options**</td></tr>
+<tr><td>`expression=*`</td><td>Matches all (remaining) pages. If this is the first filter expression it will match all pages.</td></tr>
+<tr><td>`expression=*string*`</td><td>Matches all (remaining) URLs containing the text string.</td></tr>
+<tr><td>`expression=^*string*`</td><td>Matches all (remaining) URLs starting with the text string.</td></tr>
+<tr><td>`expression=$*string*`</td><td>Matches all (remaining) URLs ending with the text string.</td></tr>
 <tr><td>
-<div><code>expression=!<em>string</em></code>,<br />
-<code>expression=!^<em>string</em></code>,<br />
-<code>expression=!$<em>string</em></code></td><td>Matches all (remaining) URLs <em>not</em> containing, starting with, or ending with the text string.</td></tr>
-<tr><td colspan="2">Multiple expressions can be combined in the same filter using <code>&amp;&amp;</code>. This will require all expressions to match. Ampersands should be url-encoded, e.g. <code>&expression=products%26%26^https%26%26!$.html</code>.</td></tr>
+<div>`expression=!*string*`,<br />
+`expression=!^*string*`,<br />
+`expression=!$*string*`</td><td>Matches all (remaining) URLs *not* containing, starting with, or ending with the text string.</td></tr>
+<tr><td colspan="2">Multiple expressions can be combined in the same filter using `&&`. This will require all expressions to match. Ampersands should be url-encoded, e.g. `&expression=products%26%26^https%26%26!$.html`.</td></tr>
 
-<tr><td colspan="2"><strong>Filter actions</strong></td></tr>
-<tr><td><code>action=doNotCrawl</code></td><td>Do not crawl/visit the matching pages.</td></tr>
-<tr><td><code>action=doNotProcess</code></td><td>Do not process the matching pages. Will still crawl the matching pages for links.</td></tr>
-<tr><td><code>action=<em>Diffbot API</em></code></td><td>Process the matching pages via the specified Diffbot API.
+<tr><td colspan="2">**Filter actions**</td></tr>
+<tr><td>`action=doNotCrawl`</td><td>Do not crawl/visit the matching pages.</td></tr>
+<tr><td>`action=doNotProcess`</td><td>Do not process the matching pages. Will still crawl the matching pages for links.</td></tr>
+<tr><td>`action=*Diffbot API*`</td><td>Process the matching pages via the specified Diffbot API.
 </td></tr>
 </tbody>
 </table>
 -->
-<h4>Response</h4>
-<p>Upon adding a new crawl, you will receive a success message in the JSON response, in addition to full crawl details:</p>
 
+### Response
 
-```text
+Upon adding a new crawl, you will receive a success message in the JSON response, in addition to full crawl details:
 
-  "response": "Successfully added urls for spidering."
-
+```json
+"response": "Successfully added urls for spidering."
 ```
 
+Please note that if you get the "Too Many Collections" error, you hit our 1000-active-crawls limit. More information [here](error-too-many-collections.md).
 
+## Pausing, Restarting or Deleting Crawls
 
-<p>Please note that if you get the "Too Many Collections" error, you hit our 1000-active-crawls limit. More information <a href="error-too-many-collections">here</a>.</p>
+You can manage your crawls by making POST requests to the same endpoint, `https://api.diffbot.com/v3/crawl`.
 
-<hr>
+Provide the following data:
 
-<h3 id="pausedelete">Pausing, Restarting or Deleting Crawls</h3>
-<p>You can manage your crawls by making POST requests to the same endpoint, <code>https://api.diffbot.com/v3/crawl</code>.</p>
-<p>Provide the following data:</p>
+| Argument | Description |
+| :------- | :---------- |
+| `token` | Developer [token](https://diffbot.com/pricing). |
+| `name` | Job name as defined when the crawl was created. </td></tr><td colspan="2">**Job-control arguments** |
+| `roundStart` | Pass `roundStart=1` to force the start of a new crawl "round" (manually repeat the crawl). If `onlyProcessIfNew` is set to 1 (default), only newly-created pages will be processed. |
+| `pause` | Pass `pause=1` to pause a crawl. Pass `pause=0` to resume a paused crawl. |
+| `restart` | Restart removes all crawled data while maintaining crawl settings. Pass `restart=1` to restart a crawl. |
+| `delete` | Pass `delete=1` to delete a crawl, and all associated data, completely. |
 
-<table class="controls table table-bordered" border="0" cellpadding="5">
-<thead><tr>
-<th>Parameter</th>
-<th>Description</th>
-</tr></thead>
-<tbody>
-<tr>
-<td><code>token</code></td>
-<td>Developer <a href="https://diffbot.com/pricing">token</a>
-</td>
-</tr>
-<tr>
-<td><code>name</code></td>
-<td>Job name as defined when the crawl was created.</td>
-</tr>
-<tr>
-<td colspan="2"><strong>Job-control arguments</strong></td>
-</tr>
-<tr>
-<td><code>roundStart</code></td>
-<td>Pass <code>roundStart=1</code> to force the start of a new crawl "round" (manually repeat the crawl). If <code>onlyProcessIfNew</code> is set to 1 (default), only newly-created pages will be processed.</td>
-</tr>
-<tr>
-<td><code>pause</code></td>
-<td>Pass <code>pause=1</code> to pause a crawl. Pass <code>pause=0</code> to resume a paused crawl.</td>
-</tr>
-<tr>
-<td><code>restart</code></td>
-<td>Restart removes all crawled data while maintaining crawl settings. Pass <code>restart=1</code> to restart a crawl.</td>
-</tr>
-<tr>
-<td><code>delete</code></td>
-<td>Pass <code>delete=1</code> to delete a crawl, and all associated data, completely.</td>
-</tr>
-</tbody>
-</table>
+## Retrieving Crawlbot API Data
 
-<hr>
+To download results please make a GET request to `https://api.diffbot.com/v3/crawl/data`. Provide the following arguments based on the data you need. By default the complete extracted JSON data will be downloaded.
 
-<h3 id="retrieving">Retrieving Crawlbot API Data</h3>
-<p>To download results please make a GET request to <code>https://api.diffbot.com/v3/crawl/data</code>. Provide the following arguments based on the data you need. By default the complete extracted JSON data will be downloaded.</p>
-<table class="controls table table-bordered" border="0" cellpadding="5">
-<thead><tr>
-<th>Parameter</th>
-<th>Description</th>
-</tr></thead>
-<tbody>
-<tr>
-<td><code>token</code></td>
-<td>Diffbot token.</td>
-</tr>
-<tr>
-<td><code>name</code></td>
-<td>Name of the crawl whose data you wish to download.</td>
-</tr>
-<tr>
-<td><code>format</code></td>
-<td>Request <code>format=csv</code> to download the extracted data in CSV format (default: <code>json</code>). Note that CSV files will only contain top-level fields.</td>
-</tr>
-<tr><td colspan="2"><strong>For diagnostic data:</strong></td></tr>
-<tr>
-<td><code>type</code></td>
-<td>Request <code>type=urls</code> to retrieve the crawl <a href="explain-crawl-url-report">URL Report</a> (CSV).</td>
-</tr>
-<tr>
-<td><code>num</code></td>
-<td>Pass an integer value (e.g. <code>num=100</code>) to request a subset of URLs, most recently crawled first.</td>
-</tr>
-</tbody>
-</table>
+| Argument | Description |
+| :------- | :---------- |
+| `token` | Developer [token](https://diffbot.com/pricing). |
+| `name` | Name of the crawl whose data you wish to download. |
+| `format` | Request `format=csv` to download the extracted data in CSV format (default: `json`). Note that CSV files will only contain top-level fields. </td></tr><td colspan="2">**For diagnostic data:**</td> |
+| `type` | Request `type=urls` to retrieve the crawl [URL Report](explain-crawl-url-report.md) (CSV). |
+| `num` | Pass an integer value (e.g. `num=100`) to request a subset of URLs, most recently crawled first. |
 
-<h3>Using the Search API to Retrieve Crawl Data</h3>
-<p>You can also use Diffbot's <a href="api-search">Search API</a> to fine-tune the data retrieved from your Crawlbot or Bulk API jobs.</p>
-<p><a href="api-search">Search API documentation</a></p>
+## Using the Search API to Retrieve Crawl Data
 
-<hr>
+You can also use Diffbot's [Search API](api-search.md) to fine-tune the data retrieved from your Crawlbot or Bulk API jobs.
 
+[Search API documentation](api-search.md)
 
-<h3 id="details">Viewing Crawl Details</h3>
-<p>Your crawls (along with any Bulk API jobs) will be returned in the <code>jobs</code> object in a request made to <code>https://api.diffbot.com/v3/crawl</code>.</p>
-<p>To retrieve a single crawl's details, provide the crawl's <code>name</code> in your request:</p>
-<table class="controls table table-bordered" border="0" cellpadding="5">
-<thead><tr>
-<th>Parameter</th>
-<th>Description</th>
-</tr></thead>
-<tbody>
-<tr>
-<td><code>token</code></td>
-<td>Developer <a href="https://diffbot.com/pricing">token</a>
-</td>
-</tr>
-<tr>
-<td><code>name</code></td>
-<td>Name of crawl to retrieve.</td>
-</tr>
-</tbody>
-</table>
+## Viewing Crawl Details
 
-<p>To view all crawls (and bulk jobs), simply omit the <code>name</code> parameter: <code>https://api.diffbot.com/v3/crawl?token={{token}}</code></p>
+Your crawls (along with any Bulk API jobs) will be returned in the `jobs` object in a request made to `https://api.diffbot.com/v3/crawl`.
 
-<h4>
-<a name="response"></a>Response</h4>
-<p>This will return a JSON response of your token's crawls (and Bulk API) jobs in the <code>jobs</code> object. If you have specified a single job name, only one job's details will be returned.</p>
-<p>Sample response from a single crawl:</p>
+To retrieve a single crawl's details, provide the crawl's `name` in your request:
 
-<!--{codesample1}-->
+| Argument | Description |
+| :------- | :---------- |
+| `token` | Developer [token](https://diffbot.com/pricing). |
+| `name` | Name of crawl to retrieve. |
 
-```text
+To view all crawls (and bulk jobs), simply omit the `name` parameter: `https://api.diffbot.com/v3/crawl?token={{token}}`
+
+<a name="json-metadata"></a>
+
+### Response
+
+This will return a JSON response of your token's crawls (and Bulk API) jobs in the `jobs` object. If you have specified a single job name, only one job's details will be returned.
+
+Sample response from a single crawl:
+
+```json
 {
   "jobs": [
     {
@@ -351,71 +194,20 @@ todo: Modify links to old API docs
 }
 ```
 
+## Status Codes
 
-<!--{endcodesample1}-->
+The `jobStatus` object will return the following status codes and associated messages:
 
-
-<h3 id="status">Status Codes</h3>
-<p>The <code>jobStatus</code> object will return the following status codes and associated messages:</p>
-
-<table class="controls table table-bordered table-condensed" border="0" cellpadding="5">
-<thead><tr>
-<th>Status</th>
-<th>Message</th>
-</tr></thead>
-<tbody>
-<tr>
-<td>0</td>
-<td>Job is initializing</td>
-</tr>
-<tr>
-<td>1</td>
-<td>Job has reached maxRounds limit</td>
-</tr>
-<tr>
-<td>2</td>
-<td>Job has reached maxToCrawl limit</td>
-</tr>
-<tr>
-<td>3</td>
-<td>Job has reached maxToProcess limit</td>
-</tr>
-<tr>
-<td>4</td>
-<td>Next round to start in _____ seconds</td>
-</tr>
-<tr>
-<td>5</td>
-<td>No URLs were added to the crawl</td>
-</tr>
-<tr>
-<td>6</td>
-<td>Job paused</td>
-</tr>
-<tr>
-<td>7</td>
-<td>Job in progress</td>
-</tr>
-<tr>
-<td>8</td>
-<td>All crawling temporarily paused by root administrator for maintenance</td>
-</tr>
-<tr>
-<td>9</td>
-<td>Job has completed and no repeat is scheduled</td>
-</tr>
-<tr>
-<td>10</td>
-<td>Failed to crawl any seed<br><em>Indicates a problem retrieving links from the seed URL(s)</em>
-</td>
-</tr>
-</tbody>
-</table>
-
-
-
-</div>
-
-
-
-</div>
+| Status | Message |
+| :----- | :------ |
+| 0 | Job is initializing |
+| 1 | Job has reached maxRounds limit |
+| 2 | Job has reached maxToCrawl limit |
+| 3 | Job has reached maxToProcess limit |
+| 4 | Next round to start in _____ seconds |
+| 5 | No URLs were added to the crawl |
+| 6 | Job paused |
+| 7 | Job in progress |
+| 8 | All crawling temporarily paused by root administrator for maintenance |
+| 9 | Job has completed and no repeat is scheduled |
+| 10 | Failed to crawl any seed<br>*Indicates a problem retrieving links from the seed URL(s)* |

--- a/docs/api-custom.md
+++ b/docs/api-custom.md
@@ -7,104 +7,79 @@ todo: Modify links to old API docs
 todo: Modify links to old Dashboard
 ---
 
-<div id="docBody">
-<p>Custom APIs allow you to extract nearly anything from nearly any site using Diffbot's powerful rendering engine.</p>
-<div class="alert alert-info">
-<strong>Related:</strong> <a href="http://support.diffbot.com/topics/apitoolkit/" target="_blank">API Toolkit Support</a> | <a href="api-managing-rules-programmatically">Managing Rules Programmatically</a> | <a href="tutorials-custom-video">Video Tutorials</a>
-</div>
-<h3 id="request">Creating a New API</h3>
-<p>You first need to create a custom API using our <a href="/dev/customize">API Toolkit</a>. Point-and-click or use CSS selectors to identify the content you wish to extract from a sample page. Your new API will be ready immediately, either for individual calls, your own app integration, or from within <a href="/dev/crawl">Crawlbot</a> or our <a href="/dev/bulk">Bulk API</a> systems.</p>
+Custom APIs allow you to extract nearly anything from nearly any site using Diffbot's powerful rendering engine.
 
-<p>Custom APIs use Diffbot's cloud-based rendering engine, and fully execute most page-level Javascript in order to access Ajax-delivered elements.</p>
+<div class="info"><strong>Related:</strong> <a href="https://support.diffbot.com/topics/apitoolkit/" target="_blank">API Toolkit Support</a> | <a href="api-managing-rules-programmatically">Managing Rules Programmatically</a> | <a href="tutorials-custom-video">Video Tutorials</a></div>
 
-<p>For assistance in creating your custom API, please see <a href="api-selectors-filters">Selectors and Filters</a>.</p>
+## Creating a New API
 
-<h3 id="request">Request</h3>
-<div class="indent">
-<p>To access your Custom API, perform a HTTP GET request on the API you created in the <a href="/dev/customize">API Toolkit</a>:</p>
-  
+You first need to create a custom API using our <a href="/dev/customize">API Toolkit</a>. Point-and-click or use CSS selectors to identify the content you wish to extract from a sample page. Your new API will be ready immediately, either for individual calls, your own app integration, or from within <a href="/dev/crawl">Crawlbot</a> or our <a href="/dev/bulk">Bulk API</a> systems.
 
-```text
-https://api.diffbot.com/v3/{your API name}?token=...&amp;url=...
+Custom APIs use Diffbot's cloud-based rendering engine, and fully execute most page-level Javascript in order to access Ajax-delivered elements.
+
+For assistance in creating your custom API, please see [Selectors and Filters](api-selectors-filters.md).
+
+## Request
+
+To access your Custom API, perform a HTTP GET request on the API you created in the <a href="/dev/customize">API Toolkit</a>:
+
+```plaintext
+https://api.diffbot.com/v3/{your API name}?token=...&url=...
 ```
 
+Provide the following arguments:
 
-<p>Provide the following arguments:</p>
-<table class="controls table table-bordered" border="0" cellpadding="5">
-<thead><tr>
-<th>Argument</th>
-<th>Description</th>
-</tr></thead>
-<tbody>
-<tr>
-<td><code>token</code></td>
-<td>Developer <a href="https://diffbot.com/pricing">token</a>
-</td>
-</tr>
-<tr>
-<td><code>url</code></td>
-<td>URL to process (<a href="http://en.wikipedia.org/wiki/Percent-encoding" target="_blank">URL encoded</a>)</td>
-</tr>
-<tr><td colspan="2"><strong>Optional parameters</strong></td></tr>
-<tr class="opt">
-<td><code>callback</code></td>
-<td>Use for jsonp requests. Needed for cross-domain ajax.</td>
-</tr>
-<tr class="opt">
-<td><code>timeout</code></td>
-<td>Sets a value in milliseconds to wait for the retrieval/fetch of content from the requested URL. The default timeout for the third-party response is 30 seconds (30000).</td>
-</tr>
-</tbody>
-</table>
-<h3 id="response">Response</h3>
-<p>Custom APIs return data in JSON format.</p>
+| Argument | Description |
+| :------- | :---------- |
+| `token` | Developer [token](https://diffbot.com/pricing) |
+| `url` | URL to process ([URL encoded](https://en.wikipedia.org/wiki/Percent-encoding)) </td></tr><td colspan="2">**Optional arguments**</td> |
+| `callback` | Use for jsonp requests. Needed for cross-domain ajax. |
+| `timeout` | Sets a value in milliseconds to wait for the retrieval/fetch of content from the requested URL. The default timeout for the third-party response is 30 seconds (30000). |
 
-<p>Each response includes a <code>request</code> object (which returns request-specific metadata), and an <code>objects</code> array, which will include the extracted information for all objects on a submitted page.</p>
+## Response
 
-<p>For Custom APIs the <code>objects</code> array will always contain a single object, and all custom fields and collections will be returned therein.
+Custom APIs return data in JSON format.
 
-</p>
-<h3 id="authenticating">Authentication</h3>
-<p>You can supply Diffbot with basic authentication credentials or custom HTTP headers (see below) to access intranet pages or other sites that require a login.</p>
+Each response includes a `request` object (which returns request-specific metadata), and an `objects` array, which will include the extracted information for all objects on a submitted page.
 
-<h4>Basic Authentication</h4>
-<p>To access pages that require a login/password (using <a href="http://en.wikipedia.org/wiki/Basic_access_authentication" target="_blank">basic access authentication</a>), include the username and password in your <code>url</code> parameter, e.g.: <code>url=http%3A%2F%2FUSERNAME:PASSWORD@www.diffbot.com</code>.</p>
+For Custom APIs the `objects` array will always contain a single object, and all custom fields and collections will be returned therein.
 
-<h3 id="customheaders">Custom HTTP Headers</h3>
-<p>You can supply Diffbot APIs with custom HTTP headers that will be passed along when making requests to third-party sites. These can be used to define specific Referer, User-Agent, Cookie or any other values.</p>
-<p>Custom headers should be sent as HTTP headers in your request to <code>https://api.diffbot.com</code>, and prepended with <code>X-Forward-</code>.</p>
-<p>For instance, to send custom <code>User-Agent</code>, <code>Referer</code> and <code>My-Custom-Header</code> header values:</p>
-<table class="controls table table-bordered" border="0" cellpadding="5">
-<thead><tr>
-<th>Desired Header</th>
-<th>Send to api.diffbot.com</th>
-</tr></thead>
-<tbody>
-<tr>
-<td><code>User-Agent:Diffbot</code></td>
-<td><code>X-Forward-User-Agent:Diffbot</code></td>
-</tr>
-<tr>
-<td><code>Referer:diffbot.com</code></td>
-<td><code>X-Forward-Referer:diffbot.com</code></td>
-</tr>
-<tr>
-<td><code>My-Custom-Header:CustomValue</code></td>
-<td><code>X-Forward-My-Custom-Header:CustomValue</code></td>
-</tr>
-</tbody>
-</table>
+## Authentication
 
-<h3 id="x-evaluate">Custom Javascript</h3>
+You can supply Diffbot with basic authentication credentials or custom HTTP headers (see below) to access intranet pages or other sites that require a login.
+
+### Basic Authentication
+
+To access pages that require a login/password (using [basic access authentication](https://en.wikipedia.org/wiki/Basic_access_authentication)), include the username and password in your `url` parameter, e.g.: `url=http%3A%2F%2FUSERNAME:PASSWORD@www.diffbot.com`.
+
+## Custom HTTP Headers
+
+You can supply Diffbot APIs with custom HTTP headers that will be passed along when making requests to third-party sites. These can be used to define specific Referer, User-Agent, Cookie or any other values.
+
+Custom headers should be sent as HTTP headers in your request to `https://api.diffbot.com`, and prepended with `X-Forward-`.
+
+For instance, to send custom `User-Agent`, `Referer` and `My-Custom-Header` header values:
+
+| Desired Header | Send to api.diffbot.com |
+| :-- | :-- |
+| `User-Agent:Diffbot` | `X-Forward-User-Agent:Diffbot` |
+| `Referer:diffbot.com` | `X-Forward-Referer:diffbot.com` |
+| `My-Custom-Header:CustomValue` | `X-Forward-My-Custom-Header:CustomValue` |
+
+## Custom Javascript
+
 <div class="alert">This functionality is currently in beta.</div>
-<p>Using the <code>X-Evaluate</code> custom header (sent as <code>X-Forward-X-Evaluate</code>), you can inject your own Javascript code into web pages. Custom Javascript will be executed once the DOM has loaded.</p>
-<p>Custom Javascript should be provided as a text string and contained in its own function. You must also include the special functions <code>start()</code> and <code>end()</code> to indicate the beginning and end of your custom script. Once <code>end()</code> fires, the updated document will be processed by your chosen extraction API.</p>
-<p>It's recommended that your <code>end()</code> function be offset using <code>setTimeout</code> (see <a href="http://www.w3schools.com/js/js_timing.asp" target="_blank">JavaScript Timing Events</a>) in order to accommodate your primary function processing. Additionally, if your custom Javascript requires access to Ajax-delivered content, it may be necessary to offset your entire function using <code>setTimeout</code> in order to delay the start of your processing.</p>
-<p>The following sample <code>X-Evaluate</code> header waits one-half second after the DOM has loaded, enacts a click on the <code>a.loadMore</code> element, then waits 800 milliseconds before signaling the <code>end()</code>:</p>
+
+Using the `X-Evaluate` custom header (sent as `X-Forward-X-Evaluate`), you can inject your own Javascript code into web pages. Custom Javascript will be executed once the DOM has loaded.
+
+Custom Javascript should be provided as a text string and contained in its own function. You must also include the special functions `start()` and `end()` to indicate the beginning and end of your custom script. Once `end()` fires, the updated document will be processed by your chosen extraction API.
+
+It's recommended that your `end()` function be offset using `setTimeout` (see [JavaScript Timing Events](https://www.w3schools.com/js/js_timing.asp)) in order to accommodate your primary function processing. Additionally, if your custom Javascript requires access to Ajax-delivered content, it may be necessary to offset your entire function using `setTimeout` in order to delay the start of your processing.
+
+The following sample `X-Evaluate` header waits one-half second after the DOM has loaded, enacts a click on the `a.loadMore` element, then waits 800 milliseconds before signaling the `end()`:
 
 
-```text
-
+```js
 function() {
     start();
     setTimeout(function() {
@@ -119,41 +94,28 @@ function() {
         }
     }, 500);
 }
-
 ```
 
+Delivered as a string value as a custom header:
 
-
-<p>Delivered as a string value as a custom header:</p>
-
-
-```text
+```json
 "X-Forward-X-Evaluate": "function() {start();setTimeout(function(){var loadMoreNode=document.querySelector('a.loadMore');if (loadMoreNode != null) {loadMoreNode.click();setTimeout(function(){end();}, 800);} else {end();}},500);}"
 ```
 
+## Posting Content
 
+If your content is not publicly available (e.g., behind a firewall), you can POST markup directly to your Custom API endpoint for analysis:
 
-<h3 id="posting">Posting Content</h3>
-<p>If your content is not publicly available (e.g., behind a firewall), you can POST markup directly to your Custom API endpoint for analysis:
-</p>
-
-
-```text
-https://api.diffbot.com/v3/yourcustomapi?token=...&amp;url=...
+```plaintext
+https://api.diffbot.com/v3/{your API name}?token=...&url=...
 ```
 
+Please note that the `url` argument is still required, and will be used to resolve any relative links contained in the markup.
 
-<p>Please note that the <code>url</code> argument is still required, and will be used to resolve any relative links contained in the markup.</p>
-<p>Provide the content to analyze as your POST body, and specify the <code>Content-Type</code> header as <code>text/html</code>.</p>
-<p><strong>HTML Post Sample</strong>:</p>
-  
+Provide the content to analyze as your POST body, and specify the `Content-Type` header as `text/html`.
 
-```text
+### HTML Post Sample
 
-curl -H "Content-Type: text/html" -d '&lt;html&gt;&lt;body&gt;&lt;h2&gt;A Pair of Jeans&lt;/h2&gt;&lt;div&gt;Price: $31.99&lt;/div&gt;&lt;/body&gt;&lt;/html&gt;' https://api.diffbot.com/v3/yourcustomapi?token=...&amp;url=http%3A%2F%2Fstore.diffbot.com
+```plaintext
+curl -H "Content-Type: text/html" -d '<html><body><h2>A Pair of Jeans</h2><div>Price: $31.99</div></body></html>' https://api.diffbot.com/v3/yourcustomapi?token=...&url=http%3A%2F%2Fstore.diffbot.com
 ```
-
-
-
-</div>
-</div>

--- a/docs/api-custom.md
+++ b/docs/api-custom.md
@@ -5,6 +5,7 @@ sidebar_label: Custom APIs
 todo: Modify link beginning with "support.diffbot.com/topics"
 todo: Modify links to old API docs
 todo: Modify links to old Dashboard
+todo: Update link that leads to old KB about api toolkit, possible when Prose sidebar revamped.
 ---
 
 Custom APIs allow you to extract nearly anything from nearly any site using Diffbot's powerful rendering engine.

--- a/docs/api-discussion.md
+++ b/docs/api-discussion.md
@@ -5,216 +5,88 @@ sidebar_label: Discussion Extraction API
 todo: Modify links to old API docs
 ---
 
-<div id="docBody">
-<p>The Discussion API automatically structures and extracts entire threads or lists of reviews/comments from most discussion pages, forums, and similarly structured web pages.</p>
-<h3>Request</h3>
-<p>To use the Discussion Thread API, perform a HTTP GET request on the following endpoint:</p>
-  
+The Discussion API automatically structures and extracts entire threads or lists of reviews/comments from most discussion pages, forums, and similarly structured web pages.
 
-```text
+## Request
+
+To use the Discussion Thread API, perform a HTTP GET request on the following endpoint:
+
+```plaintext
 https://api.diffbot.com/v3/discussion
 ```
 
+Provide the following arguments:
 
-<p>Provide the following arguments:</p>
+| Argument | Description |
+| :------- | :---------- |
+| `token` | Developer token |
+| `url` | Web page URL of the discussion to process (URL encoded) </td></tr><tr><td colspan="2">**Optional arguments**</td> |
+| `fields` | Used to specify optional fields to be returned by the Discussion API. See the [Fields](#the-fields-argument) section below. |
+| `timeout` | Sets a value in milliseconds to wait for the retrieval/fetch of content from the requested URL. The default timeout for the third-party response is 30 seconds (30000). |
+| `callback` | Use for jsonp requests. Needed for cross-domain ajax. |
+| `maxPages` | Set the maximum number of pages in a thread to automatically concatenate in a single response. Default = 1 (no concatenation). Set `maxPages=all` to retrieve all pages of a thread regardless of length. Each individual page will count as a separate API call. |
 
-<!--{arguments}--><table class="controls table table-bordered" id="arguments" border="0" cellpadding="5">
-<thead><tr>
-<th>Argument</th>
-<th>Description</th>
-</tr></thead>
+### The fields argument
 
-<tr>
-<td class=""><code>token</code></td>
-<td class=" default"><div>Developer token</div></td>
-</tr>
-<tr>
-<td class=""><code>url</code></td>
-<td class=" default"><div>Web page URL of the discussion to process (URL encoded)</div></td>
-</tr>
+Use the `fields` argument to return optional fields in the JSON response. The default fields will always be returned. For nested arrays, use parentheses to retrieve specific fields, or `*` to return all sub-fields.
 
-<tr>
-<td colspan="2" class="header">Optional arguments</td>
-</tr>
-<tr>
-<td class=""><code>fields</code></td>
-<td class=" optional"><div>Used to specify optional fields to be returned by the Discussion API. See the <a href="#fields">Fields</a> section below.</div></td>
-</tr>
-<tr>
-<td class=""><code>timeout</code></td>
-<td class=" optional"><div>Sets a value in milliseconds to wait for the retrieval/fetch of content from the requested URL. The default timeout for the third-party response is 30 seconds (30000).</div></td>
-</tr>
-<tr>
-<td class=""><code>callback</code></td>
-<td class=" optional"><div>Use for jsonp requests. Needed for cross-domain ajax.</div></td>
-</tr>
-<tr>
-<td class=""><code>maxPages</code></td>
-<td class=" optional"><div>Set the maximum number of pages in a thread to automatically concatenate in a single response. Default = 1 (no concatenation). Set <code>maxPages=all</code> to retrieve all pages of a thread regardless of length. Each individual page will count as a separate API call.</div></td>
-</tr>
-</table>
-<!--{endarguments}-->
+For example, to return `meta` (in addition to the default fields), your `&fields` argument would be:
 
-<h3 id="response">Response</h3>
-<p>The Discussion API returns data in JSON format.</p>
+```plaintext
+&fields=meta
+```
 
-<p>Each V3 response includes a <code>request</code> object (which returns request-specific metadata), and an <code>objects</code> array, which will include the extracted information for all objects on a submitted page. The Discussion API returns all post data in a single object within the <code>objects</code> array.
-</p>
-<p>Within the Article and Product APIs (to extract comments or review data), discussion data will be returned within the nested <code>discussion</code> object.</p>
-<p>The Discussion API <code>objects</code> / <code>discussion</code> response will include the following fields:</p>
+## Response
 
-<!--{fields}--><table class="controls table table-bordered" id="fields" border="0" cellpadding="5">
-<thead><tr>
-<th>Field</th>
-<th>Description</th>
-</tr></thead>
+The Discussion API returns data in JSON format.
 
-<tr>
-<td class=""><code>type</code></td>
-<td class=" default"><div>Type of object (always <code>discussion</code>).</div></td>
-</tr>
-<tr>
-<td class=""><code>pageUrl</code></td>
-<td class=" default"><div>URL of submitted page / page from which the discussion is extracted.</div></td>
-</tr>
-<tr>
-<td class=""><code>resolvedPageUrl</code></td>
-<td class=" default"><div>Returned if the <code>pageUrl</code> redirects to another URL.</div></td>
-</tr>
-<tr>
-<td class=""><code>title</code></td>
-<td class=" default"><div>Title of the discussion.</div></td>
-</tr>
-<tr>
-<td class=""><code>numPosts</code></td>
-<td class=" default"><div>Number of individual posts in the thread.</div></td>
-</tr>
-<tr>
-<td class="parent"><code>posts</code></td>
-<td class="parent default"><div>Array of individual posts.</div></td>
-</tr>
-<tr>
-<td class="posts indent"><code>type</code></td>
-<td class="posts indent default"><div>Type of element (always <code>post</code>).</div></td>
-</tr>
-<tr>
-<td class="posts indent"><code>id</code></td>
-<td class="posts indent default"><div>ID of the individual post. The first post of a thread will have an ID of 0.</div></td>
-</tr>
-<tr>
-<td class="posts indent"><code>parentId</code></td>
-<td class="posts indent default"><div>ID of the parent, if the post is a reply or response.</div></td>
-</tr>
-<tr>
-<td class="posts indent"><code>text</code></td>
-<td class="posts indent default"><div>Full text of the extracted post.</div></td>
-</tr>
-<tr>
-<td class="posts indent"><code>html</code></td>
-<td class="posts indent default"><div>Diffbot-normalized HTML of the extracted post. Please see the <a href="api-article-html">HTML Specification</a> for a breakdown of elements and attributes returned.</div></td>
-</tr>
-<tr>
-<td class="posts indent"><code>tags</code></td>
-<td class="posts indent default"><div>If the post is long enough, an array of tags generated from its specific content.</div></td>
-</tr>
-<tr>
-<td class="posts indent"><code>humanLanguage</code></td>
-<td class="posts indent default"><div>Spoken/human language of the post, using two-letter <a href="http://en.wikipedia.org/wiki/List_of_ISO_639-1_codes" target="_blank">ISO 639-1 nomenclature</a>.</div></td>
-</tr>
-<tr>
-<td class="posts indent"><code>images</code></td>
-<td class="posts indent default"><div>If any images are detected within post content, they will be returned in a separate array. Individual array fields are the same as the <a href="api-article">Article API's</a> <code>images</code> array.</div></td>
-</tr>
-<tr>
-<td class="posts indent"><code>date</code></td>
-<td class="posts indent default"><div>Date of post, normalized in most cases to <a href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec3.html#sec3.3">RFC 1123 (HTTP/1.1)</a>.</div></td>
-</tr>
-<tr>
-<td class="posts indent"><code>author</code></td>
-<td class="posts indent default"><div>Name/username of the post author.</div></td>
-</tr>
-<tr>
-<td class="posts indent"><code>authorUrl</code></td>
-<td class="posts indent default"><div>URL of the author profile page, if available.</div></td>
-</tr>
-<tr>
-<td class="posts indent"><code>pageUrl</code></td>
-<td class="posts indent default"><div>URL of the page on which the post was found.</div></td>
-</tr>
-<tr>
-<td class="posts indent"><code>diffbotUri</code></td>
-<td class="posts indent default"><div>Internal ID used for indexing.</div></td>
-</tr>
-<tr>
-<td class=""><code>tags</code></td>
-<td class=" default"><div>Array of tags/entities as generated from analysis of all extracted <code>posts</code> and cross-referenced with <a href="http://wiki.dbpedia.org/About" target="_new">DBpedia</a> and other data sources.</div></td>
-</tr>
-<tr>
-<td class=""><code>participants</code></td>
-<td class=" default"><div>Number of unique participants in the discussion thread or comments.</div></td>
-</tr>
-<tr>
-<td class=""><code>numPages</code></td>
-<td class=" default"><div>Number of pages in the thread concatenated to form the <code>posts</code> response. Use <code>maxPages</code> to define how many pages to concatenate. <a href="guides-multi-page-articles-discussions">More on automatic concatenation</a>.</div></td>
-</tr>
-<tr>
-<td class=""><code>nextPage</code></td>
-<td class=" default"><div>If discussion spans multiple pages, <code>nextPage</code> will return the subsequent page URL.</div></td>
-</tr>
-<tr>
-<td class=""><code>nextPages</code></td>
-<td class=" default"><div>Array of all page URLs concatenated in a multipage discussion. <a href="guides-multi-page-articles-discussions">More on automatic concatenation</a>.</div></td>
-</tr>
-<tr>
-<td class=""><code>provider</code></td>
-<td class=" default"><div>Discussion service provider (e.g., Disqus, Facebook), if known.</div></td>
-</tr>
-<tr>
-<td class=""><code>humanLanguage</code></td>
-<td class=" default"><div>Spoken/human language of the discussion / comment thread, using two-letter <a href="http://en.wikipedia.org/wiki/List_of_ISO_639-1_codes" target="_blank">ISO 639-1 nomenclature</a>.</div></td>
-</tr>
-<tr>
-<td class=""><code>rssUrl</code></td>
-<td class=" default"><div>URL of the discussion's RSS feed, if available.</div></td>
-</tr>
-<tr>
-<td class=""><code>diffbotUri</code></td>
-<td class=" default"><div>Unique object ID. The <code>diffbotUri</code> is generated from the values of various Discussion fields and uniquely identifies the object. This can be used for deduplication.</div></td>
-</tr>
+Each V3 response includes a `request` object (which returns request-specific metadata), and an `objects` array, which will include the extracted information for all objects on a submitted page. The Discussion API returns all post data in a single object within the `objects` array.
 
-<tr>
-<td colspan="2" class="header">Optional fields, available using <code>fields=</code> argument</td>
-</tr>
-<tr>
-<td class=""><code>sentiment</code></td>
-<td class=" optional"><div>Returns a sentiment score of each individual post, a value ranging from -1.0 (very negative) to 1.0 (very positive). For English-language posts only.</div></td>
-</tr>
-<tr>
-<td class=""><code>links</code></td>
-<td class=" optional"><div>Returns a top-level object (<code>links</code>) containing all hyperlinks found on the page.</div></td>
-</tr>
-<tr>
-<td class=""><code>meta</code></td>
-<td class=" optional"><div>Returns a top-level object (<code>meta</code>) containing the full contents of page <code>meta</code> tags, including sub-arrays for <a href="http://ogp.me/" target="_new">OpenGraph</a> tags, <a href="https://dev.twitter.com/docs/cards/markup-reference" target="_new">Twitter Card</a> metadata, <a href="http://www.schema.org" target="_new">schema.org</a> microdata, and -- if available -- <a href="http://www.oembed.com" target="_new">oEmbed</a> metadata.</div></td>
-</tr>
-<tr>
-<td class=""><code>querystring</code></td>
-<td class=" optional"><div>Returns any key/value pairs present in the URL querystring. Items without a discrete value will be returned as <code>true</code>.</div></td>
-</tr>
-<tr>
-<td class=""><code>breadcrumb</code></td>
-<td class=" optional"><div>Returns a top-level array (<code>breadcrumb</code>) of URLs and link text from page breadcrumbs.</div></td>
-</tr>
-</table>
-<!--{endfields}-->
+Within the Article and Product APIs (to extract comments or review data), discussion data will be returned within the nested `discussion` object.
 
+The Discussion API `objects` / `discussion` response will include the following fields:
 
-<h3>Example Response</h3>
-<p>The following response shows the extracted contents from <a href="https://news.ycombinator.com/item?id=5608988" target="_blank">this Hacker News discussion thread</a>:</p>
-<div class="indent">
-<!--{codesample1}-->
+| Field | Description |
+| :---- | :---------- |
+| `type` | Type of object (always `discussion`). |
+| `pageUrl` | URL of submitted page / page from which the discussion is extracted. |
+| `resolvedPageUrl` | Returned if the `pageUrl` redirects to another URL. |
+| `title` | Title of the discussion. |
+| `numPosts` | Number of individual posts in the thread. |
+| `posts` | Array of individual posts. |
+| &#x21B3;`type` | Type of element (always `post`). |
+| &#x21B3;`id` | ID of the individual post. The first post of a thread will have an ID of 0. |
+| &#x21B3;`parentId` | ID of the parent, if the post is a reply or response. |
+| &#x21B3;`text` | Full text of the extracted post. |
+| &#x21B3;`html` | Diffbot-normalized HTML of the extracted post. Please see the [HTML Specification](api-article-html.md) for a breakdown of elements and attributes returned. |
+| &#x21B3;`tags` | If the post is long enough, an array of tags generated from its specific content. |
+| &#x21B3;`humanLanguage` | Spoken/human language of the post, using two-letter [ISO 639-1 nomenclature](https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes). |
+| &#x21B3;`images` | If any images are detected within post content, they will be returned in a separate array. Individual array fields are the same as the [Article API's](api-article.md) `images` array. |
+| &#x21B3;`date` | Date of post, normalized in most cases to [RFC 1123 (HTTP/1.1)](https://www.w3.org/Protocols/rfc2616/rfc2616-sec3.html#sec3.3). |
+| &#x21B3;`author` | Name/username of the post author. |
+| &#x21B3;`authorUrl` | URL of the author profile page, if available. |
+| &#x21B3;`pageUrl` | URL of the page on which the post was found. |
+| &#x21B3;`diffbotUri` | Internal ID used for indexing. |
+| `tags` | Array of tags/entities as generated from analysis of all extracted `posts` and cross-referenced with [DBpedia](https://wiki.dbpedia.org/About) and other data sources. |
+| `participants` | Number of unique participants in the discussion thread or comments. |
+| `numPages` | Number of pages in the thread concatenated to form the `posts` response. Use `maxPages` to define how many pages to concatenate. [More on automatic concatenation](guides-multi-page-articles-discussions.md). |
+| `nextPage` | If discussion spans multiple pages, `nextPage` will return the subsequent page URL. |
+| `nextPages` | Array of all page URLs concatenated in a multipage discussion. [More on automatic concatenation](guides-multi-page-articles-discussions.md). |
+| `provider` | Discussion service provider (e.g., Disqus, Facebook), if known. |
+| `humanLanguage` | Spoken/human language of the discussion / comment thread, using two-letter [ISO 639-1 nomenclature](https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes). |
+| `rssUrl` | URL of the discussion's RSS feed, if available. |
+| `diffbotUri` | Unique object ID. The `diffbotUri` is generated from the values of various Discussion fields and uniquely identifies the object. This can be used for deduplication. </td></tr><tr><td colspan="2">**Optional fields, available using `fields=` argument**</td> |
+| `sentiment` | Returns a sentiment score of each individual post, a value ranging from -1.0 (very negative) to 1.0 (very positive). For English-language posts only. |
+| `links` | Returns a top-level object (`links`) containing all hyperlinks found on the page. |
+| `meta` | Returns a top-level object (`meta`) containing the full contents of page `meta` tags, including sub-arrays for [OpenGraph](https://ogp.me/) tags, [Twitter Card](https://developer.twitter.com/en/docs/tweets/optimize-with-cards/overview/markup) metadata, [schema.org](https://www.schema.org) microdata, and -- if available -- [oEmbed](https://www.oembed.com) metadata. |
+| `querystring` | Returns any key/value pairs present in the URL querystring. Items without a discrete value will be returned as `true`. |
+| `breadcrumb` | Returns a top-level array (`breadcrumb`) of URLs and link text from page breadcrumbs. |
 
-```text
+## Example Response
+
+The following response shows the extracted contents from [this Hacker News discussion thread](https://news.ycombinator.com/item?id=5608988):
+
+```json
 {
   "request": {
     "pageUrl": "https://news.ycombinator.com/item?id=5608988",
@@ -237,10 +109,10 @@ https://api.diffbot.com/v3/discussion
           "author": "miket",
           "authorUrl": "https://news.ycombinator.com/user?id=miket",
           "diffbotUri": "post|3|1167619016",
-          "html": "&lt;table&gt; &lt;tbody&gt;&lt;tr&gt;&lt;td&gt;&lt;table&gt; &lt;tbody&gt;&lt;tr&gt;&lt;td&gt; &lt;a href=\"https://news.ycombinator.com/user?id=johncoogan\"&gt;johncoogan&lt;/a&gt; &lt;a href=\"https://news.ycombinator.com/item?id=5609164\"&gt;1132 days ago&lt;/a&gt;   &lt;br&gt; Huge fan of DiffBot and awesome projects like this. Really cool analysis, thanks for posting.&lt;p&gt;Would be possible for you to post / send me the original data? I have been very interested in working on more longitudinal analysis using DiffBot data and this seems like a fun and interesting place to start. I'm happy to open-source / clearly attribute DiffBot's contribution to whatever I find / hack together, and would feel a lot more comfortable about integrating DiffBot into larger projects in the future.&lt;/p&gt;&lt;p&gt;Please email me (in my profile) if this is a possibility. Thanks!&lt;/p&gt; &lt;p&gt; -----  &lt;/p&gt;&lt;/td&gt;&lt;/tr&gt; &lt;/tbody&gt;&lt;/table&gt;&lt;/td&gt;&lt;/tr&gt; &lt;tr&gt;&lt;td&gt;&lt;table&gt; &lt;tbody&gt;&lt;tr&gt;&lt;td&gt; &lt;a href=\"https://news.ycombinator.com/user?id=tswaterman\"&gt;tswaterman&lt;/a&gt; &lt;a href=\"https://news.ycombinator.com/item?id=5609252\"&gt;1132 days ago&lt;/a&gt;   &lt;br&gt; Great idea! We'd be happy to share/help. If more people are interested, we'll figure out a good way to distribute the dataset generally. But in fact, you can extract the same data set, and add whatever other smart things you want along with it, using the Diffbot APIs. Everything we did to get this information is explained on our blog at&lt;pre&gt;&lt;code&gt;    http://blog.diffbot.com/diffbots-hackernews-trend-analyzer/\n&lt;/code&gt;&lt;/pre&gt; Sounds like you're already using the Diffbot service, but for anyone who's not, they can sign up for a free access token on our 'pricing' page at &lt;a href=\"http://www.diffbot.com/\"&gt;http://www.diffbot.com/&lt;/a&gt; It's a few hundred thousand pages you'd need to analyze to get this, which doesn't quite fit under the free plan. You might not want to analyze as many years worth of stuff as we did for this demo, though.&lt;p&gt;All the pieces and services we used for this, including all the text extraction, topic detection, and crawling, are available to any user.&lt;/p&gt;&lt;p&gt;Have fun with it, and keep us informed about whatever cool stuff you build with it, and of course tell us about any features or capabilities you wish Diffbot can provide.&lt;/p&gt; &lt;p&gt; -----  &lt;/p&gt;&lt;/td&gt;&lt;/tr&gt; &lt;/tbody&gt;&lt;/table&gt;&lt;/td&gt;&lt;/tr&gt; &lt;tr&gt;&lt;td&gt;&lt;table&gt; &lt;tbody&gt;&lt;tr&gt;&lt;td&gt; &lt;a href=\"https://news.ycombinator.com/user?id=tliou\"&gt;tliou&lt;/a&gt; &lt;a href=\"https://news.ycombinator.com/item?id=5609057\"&gt;1132 days ago&lt;/a&gt;   &lt;br&gt; Had to figure out how to use it ... but interesting once you do! Android vs IPhone on Hackernews frontpage shows spike in iphone on launch dates, but mediocre to no activity for android. is it because android is less interesting and not as innovative? or not as fun to talk/read about?&lt;p&gt;&lt;a href=\"http://diffbot.com/robotlab/hackernews/#type=tags&amp;item=IPhone&amp;item=Android%20(operating%20system)&amp;item=\"&gt;http://diffbot.com/robotlab/hackernews/#type=tags&amp;amp;item=I...&lt;/a&gt;&lt;/p&gt; &lt;p&gt; -----  &lt;/p&gt;&lt;/td&gt;&lt;/tr&gt; &lt;/tbody&gt;&lt;/table&gt;&lt;/td&gt;&lt;/tr&gt; &lt;tr&gt;&lt;td&gt;&lt;table&gt; &lt;tbody&gt;&lt;tr&gt;&lt;td&gt; &lt;a href=\"https://news.ycombinator.com/user?id=mayank\"&gt;mayank&lt;/a&gt; &lt;a href=\"https://news.ycombinator.com/item?id=5609116\"&gt;1132 days ago&lt;/a&gt;   &lt;br&gt; Funny, I just built a HN article catcher that uses Diffbot to collect and classify submissions from the /new page [1]. I've been a Diffbot fan for quite a while now (although their entity recognition/tag classifier needs a bit of work as you can see from the categorization on my catcher page below).&lt;p&gt;[1] &lt;a href=\"http://lahiri.me/more\"&gt;http://lahiri.me/more&lt;/a&gt;&lt;/p&gt;&lt;p&gt;I should add that their API is fantastic, and far better than using BeautifulSoup/NLTK for extracting textual content from webpages.&lt;/p&gt; &lt;p&gt; -----  &lt;/p&gt;&lt;/td&gt;&lt;/tr&gt; &lt;/tbody&gt;&lt;/table&gt;&lt;/td&gt;&lt;/tr&gt; &lt;tr&gt;&lt;td&gt;&lt;table&gt; &lt;tbody&gt;&lt;tr&gt;&lt;td&gt; &lt;a href=\"https://news.ycombinator.com/user?id=tswaterman\"&gt;tswaterman&lt;/a&gt; &lt;a href=\"https://news.ycombinator.com/item?id=5609278\"&gt;1132 days ago&lt;/a&gt;   &lt;br&gt; Cool! How many articles, or what time period, did you use for this? It looks like you're using only a subset of the topic tags -- did you make a list of 'interesting stuff' to filter against? &lt;p&gt; -----  &lt;/p&gt;&lt;/td&gt;&lt;/tr&gt; &lt;/tbody&gt;&lt;/table&gt;&lt;/td&gt;&lt;/tr&gt; &lt;tr&gt;&lt;td&gt;&lt;table&gt; &lt;tbody&gt;&lt;tr&gt;&lt;td&gt; &lt;a href=\"https://news.ycombinator.com/user?id=mayank\"&gt;mayank&lt;/a&gt; &lt;a href=\"https://news.ycombinator.com/item?id=5609731\"&gt;1132 days ago&lt;/a&gt;   &lt;br&gt; It's been running for about a week I think, and I'm just taking the top 80 or so tags by article count. Glad you like it :) &lt;p&gt; -----  &lt;/p&gt;&lt;/td&gt;&lt;/tr&gt; &lt;/tbody&gt;&lt;/table&gt;&lt;/td&gt;&lt;/tr&gt; &lt;tr&gt;&lt;td&gt;&lt;table&gt; &lt;tbody&gt;&lt;tr&gt;&lt;td&gt; &lt;a href=\"https://news.ycombinator.com/user?id=minimax\"&gt;minimax&lt;/a&gt; &lt;a href=\"https://news.ycombinator.com/item?id=5609100\"&gt;1132 days ago&lt;/a&gt;   &lt;br&gt; Neat! Wish I could select by just domain name (i.e. just nytimes.com rather than dozen or so whatever.nytimes.com subdomains). &lt;p&gt; -----  &lt;/p&gt;&lt;/td&gt;&lt;/tr&gt; &lt;/tbody&gt;&lt;/table&gt;&lt;/td&gt;&lt;/tr&gt; &lt;/tbody&gt;&lt;/table&gt;",
+          "html": "<table> <tbody><tr><td><table> <tbody><tr><td> <a href=\"https://news.ycombinator.com/user?id=johncoogan\">johncoogan</a> <a href=\"https://news.ycombinator.com/item?id=5609164\">1132 days ago</a>   <br> Huge fan of DiffBot and awesome projects like this. Really cool analysis, thanks for posting.<p>Would be possible for you to post / send me the original data? I have been very interested in working on more longitudinal analysis using DiffBot data and this seems like a fun and interesting place to start. I'm happy to open-source / clearly attribute DiffBot's contribution to whatever I find / hack together, and would feel a lot more comfortable about integrating DiffBot into larger projects in the future.</p><p>Please email me (in my profile) if this is a possibility. Thanks!</p> <p> -----  </p></td></tr> </tbody></table></td></tr> <tr><td><table> <tbody><tr><td> <a href=\"https://news.ycombinator.com/user?id=tswaterman\">tswaterman</a> <a href=\"https://news.ycombinator.com/item?id=5609252\">1132 days ago</a>   <br> Great idea! We'd be happy to share/help. If more people are interested, we'll figure out a good way to distribute the dataset generally. But in fact, you can extract the same data set, and add whatever other smart things you want along with it, using the Diffbot APIs. Everything we did to get this information is explained on our blog at<pre><code>    http://blog.diffbot.com/diffbots-hackernews-trend-analyzer/\n</code></pre> Sounds like you're already using the Diffbot service, but for anyone who's not, they can sign up for a free access token on our 'pricing' page at <a href=\"http://www.diffbot.com/\">http://www.diffbot.com/</a> It's a few hundred thousand pages you'd need to analyze to get this, which doesn't quite fit under the free plan. You might not want to analyze as many years worth of stuff as we did for this demo, though.<p>All the pieces and services we used for this, including all the text extraction, topic detection, and crawling, are available to any user.</p><p>Have fun with it, and keep us informed about whatever cool stuff you build with it, and of course tell us about any features or capabilities you wish Diffbot can provide.</p> <p> -----  </p></td></tr> </tbody></table></td></tr> <tr><td><table> <tbody><tr><td> <a href=\"https://news.ycombinator.com/user?id=tliou\">tliou</a> <a href=\"https://news.ycombinator.com/item?id=5609057\">1132 days ago</a>   <br> Had to figure out how to use it ... but interesting once you do! Android vs IPhone on Hackernews frontpage shows spike in iphone on launch dates, but mediocre to no activity for android. is it because android is less interesting and not as innovative? or not as fun to talk/read about?<p><a href=\"http://diffbot.com/robotlab/hackernews/#type=tags&item=IPhone&item=Android%20(operating%20system)&item=\">http://diffbot.com/robotlab/hackernews/#type=tags&amp;item=I...</a></p> <p> -----  </p></td></tr> </tbody></table></td></tr> <tr><td><table> <tbody><tr><td> <a href=\"https://news.ycombinator.com/user?id=mayank\">mayank</a> <a href=\"https://news.ycombinator.com/item?id=5609116\">1132 days ago</a>   <br> Funny, I just built a HN article catcher that uses Diffbot to collect and classify submissions from the /new page [1]. I've been a Diffbot fan for quite a while now (although their entity recognition/tag classifier needs a bit of work as you can see from the categorization on my catcher page below).<p>[1] <a href=\"http://lahiri.me/more\">http://lahiri.me/more</a></p><p>I should add that their API is fantastic, and far better than using BeautifulSoup/NLTK for extracting textual content from webpages.</p> <p> -----  </p></td></tr> </tbody></table></td></tr> <tr><td><table> <tbody><tr><td> <a href=\"https://news.ycombinator.com/user?id=tswaterman\">tswaterman</a> <a href=\"https://news.ycombinator.com/item?id=5609278\">1132 days ago</a>   <br> Cool! How many articles, or what time period, did you use for this? It looks like you're using only a subset of the topic tags -- did you make a list of 'interesting stuff' to filter against? <p> -----  </p></td></tr> </tbody></table></td></tr> <tr><td><table> <tbody><tr><td> <a href=\"https://news.ycombinator.com/user?id=mayank\">mayank</a> <a href=\"https://news.ycombinator.com/item?id=5609731\">1132 days ago</a>   <br> It's been running for about a week I think, and I'm just taking the top 80 or so tags by article count. Glad you like it :) <p> -----  </p></td></tr> </tbody></table></td></tr> <tr><td><table> <tbody><tr><td> <a href=\"https://news.ycombinator.com/user?id=minimax\">minimax</a> <a href=\"https://news.ycombinator.com/item?id=5609100\">1132 days ago</a>   <br> Neat! Wish I could select by just domain name (i.e. just nytimes.com rather than dozen or so whatever.nytimes.com subdomains). <p> -----  </p></td></tr> </tbody></table></td></tr> </tbody></table>",
           "pageUrl": "https://news.ycombinator.com/item?id=5608988",
           "id": 0,
-          "text": "johncoogan 1132 days ago\nHuge fan of DiffBot and awesome projects like this. Really cool analysis, thanks for posting.\nWould be possible for you to post / send me the original data? I have been very interested in working on more longitudinal analysis using DiffBot data and this seems like a fun and interesting place to start. I'm happy to open-source / clearly attribute DiffBot's contribution to whatever I find / hack together, and would feel a lot more comfortable about integrating DiffBot into larger projects in the future.\nPlease email me (in my profile) if this is a possibility. Thanks!\n\n\n-----\n\n\n\n\ntswaterman 1132 days ago\nGreat idea! We'd be happy to share/help. If more people are interested, we'll figure out a good way to distribute the dataset generally. But in fact, you can extract the same data set, and add whatever other smart things you want along with it, using the Diffbot APIs. Everything we did to get this information is explained on our blog at\nhttp://blog.diffbot.com/diffbots-hackernews-trend-analyzer/ Sounds like you're already using the Diffbot service, but for anyone who's not, they can sign up for a free access token on our 'pricing' page at \nhttp://www.diffbot.com/ It's a few hundred thousand pages you'd need to analyze to get this, which doesn't quite fit under the free plan. You might not want to analyze as many years worth of stuff as we did for this demo, though.\nAll the pieces and services we used for this, including all the text extraction, topic detection, and crawling, are available to any user.\nHave fun with it, and keep us informed about whatever cool stuff you build with it, and of course tell us about any features or capabilities you wish Diffbot can provide.\n\n\n-----\n\n\n\n\ntliou 1132 days ago\nHad to figure out how to use it ... but interesting once you do! Android vs IPhone on Hackernews frontpage shows spike in iphone on launch dates, but mediocre to no activity for android. is it because android is less interesting and not as innovative? or not as fun to talk/read about?\nhttp://diffbot.com/robotlab/hackernews/#type=tags&amp;item=I...\n\n\n-----\n\n\n\n\nmayank 1132 days ago\nFunny, I just built a HN article catcher that uses Diffbot to collect and classify submissions from the /new page [1]. I've been a Diffbot fan for quite a while now (although their entity recognition/tag classifier needs a bit of work as you can see from the categorization on my catcher page below).[1] http://lahiri.me/more\nI should add that their API is fantastic, and far better than using BeautifulSoup/NLTK for extracting textual content from webpages.\n\n\n-----\n\n\n\n\ntswaterman 1132 days ago\nCool! How many articles, or what time period, did you use for this? It looks like you're using only a subset of the topic tags -- did you make a list of 'interesting stuff' to filter against?\n\n\n-----\n\n\n\n\nmayank 1132 days ago\nIt's been running for about a week I think, and I'm just taking the top 80 or so tags by article count. Glad you like it :)\n\n\n-----\n\n\n\n\nminimax 1132 days ago\nNeat! Wish I could select by just domain name (i.e. just nytimes.com rather than dozen or so whatever.nytimes.com subdomains).\n\n\n-----",
+          "text": "johncoogan 1132 days ago\nHuge fan of DiffBot and awesome projects like this. Really cool analysis, thanks for posting.\nWould be possible for you to post / send me the original data? I have been very interested in working on more longitudinal analysis using DiffBot data and this seems like a fun and interesting place to start. I'm happy to open-source / clearly attribute DiffBot's contribution to whatever I find / hack together, and would feel a lot more comfortable about integrating DiffBot into larger projects in the future.\nPlease email me (in my profile) if this is a possibility. Thanks!\n\n\n-----\n\n\n\n\ntswaterman 1132 days ago\nGreat idea! We'd be happy to share/help. If more people are interested, we'll figure out a good way to distribute the dataset generally. But in fact, you can extract the same data set, and add whatever other smart things you want along with it, using the Diffbot APIs. Everything we did to get this information is explained on our blog at\nhttp://blog.diffbot.com/diffbots-hackernews-trend-analyzer/ Sounds like you're already using the Diffbot service, but for anyone who's not, they can sign up for a free access token on our 'pricing' page at \nhttp://www.diffbot.com/ It's a few hundred thousand pages you'd need to analyze to get this, which doesn't quite fit under the free plan. You might not want to analyze as many years worth of stuff as we did for this demo, though.\nAll the pieces and services we used for this, including all the text extraction, topic detection, and crawling, are available to any user.\nHave fun with it, and keep us informed about whatever cool stuff you build with it, and of course tell us about any features or capabilities you wish Diffbot can provide.\n\n\n-----\n\n\n\n\ntliou 1132 days ago\nHad to figure out how to use it ... but interesting once you do! Android vs IPhone on Hackernews frontpage shows spike in iphone on launch dates, but mediocre to no activity for android. is it because android is less interesting and not as innovative? or not as fun to talk/read about?\nhttp://diffbot.com/robotlab/hackernews/#type=tags&item=I...\n\n\n-----\n\n\n\n\nmayank 1132 days ago\nFunny, I just built a HN article catcher that uses Diffbot to collect and classify submissions from the /new page [1]. I've been a Diffbot fan for quite a while now (although their entity recognition/tag classifier needs a bit of work as you can see from the categorization on my catcher page below).[1] http://lahiri.me/more\nI should add that their API is fantastic, and far better than using BeautifulSoup/NLTK for extracting textual content from webpages.\n\n\n-----\n\n\n\n\ntswaterman 1132 days ago\nCool! How many articles, or what time period, did you use for this? It looks like you're using only a subset of the topic tags -- did you make a list of 'interesting stuff' to filter against?\n\n\n-----\n\n\n\n\nmayank 1132 days ago\nIt's been running for about a week I think, and I'm just taking the top 80 or so tags by article count. Glad you like it :)\n\n\n-----\n\n\n\n\nminimax 1132 days ago\nNeat! Wish I could select by just domain name (i.e. just nytimes.com rather than dozen or so whatever.nytimes.com subdomains).\n\n\n-----",
           "type": "post",
           "title": "Show HN: Analysis of 2.5 Years of Frontpage Articles"
         }
@@ -262,51 +134,42 @@ https://api.diffbot.com/v3/discussion
 }
 ```
 
+## Authentication
 
-<!--{endcodesample1}-->
-</div>
+You can supply Diffbot with basic authentication credentials or custom HTTP headers (see below) to access intranet pages or other sites that require a login.
 
-<h3 id="authenticating">Authentication and Custom Headers</h3>
-<p>You can supply Diffbot with basic authentication credentials or custom HTTP headers (see below) to access intranet pages or other sites that require a login.</p>
+### Basic Authentication
 
-<h4>Basic Authentication</h4>
-<p>To access pages that require a login/password (using <a href="http://en.wikipedia.org/wiki/Basic_access_authentication" target="_blank">basic access authentication</a>), include the username and password in your <code>url</code> parameter, e.g.: <code>url=http%3A%2F%2FUSERNAME:PASSWORD@www.diffbot.com</code>.</p>
+To access pages that require a login/password (using [basic access authentication](https://en.wikipedia.org/wiki/Basic_access_authentication)), include the username and password in your `url` parameter, e.g.: `url=http%3A%2F%2FUSERNAME:PASSWORD@www.diffbot.com`.
 
-<h3 id="customheaders">Custom HTTP Headers</h3>
-<p>You can supply Diffbot APIs with custom HTTP headers that will be passed along when making requests to third-party sites. These can be used to define specific Referer, User-Agent, Cookie or any other values.</p>
-<p>Custom headers should be sent as HTTP headers in your request to <code>https://api.diffbot.com</code>, and prepended with <code>X-Forward-</code>.</p>
-<p>For instance, to send custom <code>User-Agent</code>, <code>Referer</code> and <code>My-Custom-Header</code> header values:</p>
-<table class="controls table table-bordered" border="0" cellpadding="5">
-<thead><tr>
-<th>Desired Header</th>
-<th>Send to api.diffbot.com</th>
-</tr></thead>
-<tbody>
-<tr>
-<td><code>User-Agent:Diffbot</code></td>
-<td><code>X-Forward-User-Agent:Diffbot</code></td>
-</tr>
-<tr>
-<td><code>Referer:diffbot.com</code></td>
-<td><code>X-Forward-Referer:diffbot.com</code></td>
-</tr>
-<tr>
-<td><code>My-Custom-Header:CustomValue</code></td>
-<td><code>X-Forward-My-Custom-Header:CustomValue</code></td>
-</tr>
-</tbody>
-</table>
+## Custom HTTP Headers
 
-<h3 id="x-evaluate">Custom Javascript</h3>
+You can supply Diffbot APIs with custom HTTP headers that will be passed along when making requests to third-party sites. These can be used to define specific Referer, User-Agent, Cookie or any other values.
+
+Custom headers should be sent as HTTP headers in your request to `https://api.diffbot.com`, and prepended with `X-Forward-`.
+
+For instance, to send custom `User-Agent`, `Referer` and `My-Custom-Header` header values:
+
+| Desired Header | Send to api.diffbot.com |
+| :-- | :-- |
+| `User-Agent:Diffbot` | `X-Forward-User-Agent:Diffbot` |
+| `Referer:diffbot.com` | `X-Forward-Referer:diffbot.com` |
+| `My-Custom-Header:CustomValue` | `X-Forward-My-Custom-Header:CustomValue` |
+
+## Custom Javascript
+
 <div class="alert">This functionality is currently in beta.</div>
-<p>Using the <code>X-Evaluate</code> custom header (sent as <code>X-Forward-X-Evaluate</code>), you can inject your own Javascript code into web pages. Custom Javascript will be executed once the DOM has loaded.</p>
-<p>Custom Javascript should be provided as a text string and contained in its own function. You must also include the special functions <code>start()</code> and <code>end()</code> to indicate the beginning and end of your custom script. Once <code>end()</code> fires, the updated document will be processed by your chosen extraction API.</p>
-<p>It's recommended that your <code>end()</code> function be offset using <code>setTimeout</code> (see <a href="http://www.w3schools.com/js/js_timing.asp" target="_blank">JavaScript Timing Events</a>) in order to accommodate your primary function processing. Additionally, if your custom Javascript requires access to Ajax-delivered content, it may be necessary to offset your entire function using <code>setTimeout</code> in order to delay the start of your processing.</p>
-<p>The following sample <code>X-Evaluate</code> header waits one-half second after the DOM has loaded, enacts a click on the <code>a.loadMore</code> element, then waits 800 milliseconds before signaling the <code>end()</code>:</p>
+
+Using the `X-Evaluate` custom header (sent as `X-Forward-X-Evaluate`), you can inject your own Javascript code into web pages. Custom Javascript will be executed once the DOM has loaded.
+
+Custom Javascript should be provided as a text string and contained in its own function. You must also include the special functions `start()` and `end()` to indicate the beginning and end of your custom script. Once `end()` fires, the updated document will be processed by your chosen extraction API.
+
+It's recommended that your `end()` function be offset using `setTimeout` (see [JavaScript Timing Events](https://www.w3schools.com/js/js_timing.asp)) in order to accommodate your primary function processing. Additionally, if your custom Javascript requires access to Ajax-delivered content, it may be necessary to offset your entire function using `setTimeout` in order to delay the start of your processing.
+
+The following sample `X-Evaluate` header waits one-half second after the DOM has loaded, enacts a click on the `a.loadMore` element, then waits 800 milliseconds before signaling the `end()`:
 
 
-```text
-
+```js
 function() {
     start();
     setTimeout(function() {
@@ -321,31 +184,22 @@ function() {
         }
     }, 500);
 }
-
 ```
 
+Delivered as a string value as a custom header:
 
-
-<p>Delivered as a string value as a custom header:</p>
-
-
-```text
+```json
 "X-Forward-X-Evaluate": "function() {start();setTimeout(function(){var loadMoreNode=document.querySelector('a.loadMore');if (loadMoreNode != null) {loadMoreNode.click();setTimeout(function(){end();}, 800);} else {end();}},500);}"
 ```
 
+## Posting Content
 
+If your content is not publicly available (e.g., behind a firewall), you can POST markup directly to the Discussion API endpoint for analysis:
 
-<h3 id="posting">Posting Content</h3>
-<p>If your content is not publicly available (e.g., behind a firewall), you can POST markup directly to the Discussion API endpoint for analysis:
-</p>
-
-
-```text
-https://api.diffbot.com/v3/discussion?token=...&amp;url=...
+```plaintext
+https://api.diffbot.com/v3/discussion?token=...&url=...
 ```
 
+Please note that the `url` argument is still required, and will be used to resolve any relative links contained in the markup.
 
-<p>Please note that the <code>url</code> argument is still required, and will be used to resolve any relative links contained in the markup.</p>
-<p>Provide the content to analyze as your POST body, and specify the <code>Content-Type</code> header as <code>text/html</code>.</p>
-
-</div>
+Provide the content to analyze as your POST body, and specify the `Content-Type` header as `text/html`.

--- a/docs/api-image.md
+++ b/docs/api-image.md
@@ -4,156 +4,67 @@ title: Image Extraction API
 sidebar_label: Image Extraction API
 ---
 
-<div id="docBody">
+The Image API identifies the primary image(s) of a submitted web page and returns comprehensive information and metadata for each image.
 
-<p>The Image API identifies the primary image(s) of a submitted web page and returns comprehensive information and metadata for each image.</p>
-            
-<h3 id="request">Request</h3>
-<p>To use the Image API, perform a HTTP GET request on the following endpoint:</p>
-  
+## Request
 
-```text
+To use the Image API, perform a HTTP GET request on the following endpoint:
+
+```plaintext
 https://api.diffbot.com/v3/image
 ```
 
+Provide the following arguments:
 
-<p>Provide the following arguments:</p>
+| Argument | Description |
+| :------- | :---------- |
+| `token` | Developer token |
+| `url` | Web page URL of the image to process (URL encoded) </td></tr><tr><td colspan="2">**Optional arguments**</td> |
+| `fields` | Used to specify optional fields to be returned by the Image API. See the [Fields](#the-fields-argument) section below. |
+| `timeout` | Sets a value in milliseconds to wait for the retrieval/fetch of content from the requested URL. The default timeout for the third-party response is 30 seconds (30000). |
+| `callback` | Use for jsonp requests. Needed for cross-domain ajax. |
 
-<!--{arguments}--><table class="controls table table-bordered" id="arguments" border="0" cellpadding="5">
-<thead><tr>
-<th>Argument</th>
-<th>Description</th>
-</tr></thead>
+### The fields argument
 
-<tr>
-<td class=""><code>token</code></td>
-<td class=" default"><div>Developer token</div></td>
-</tr>
-<tr>
-<td class=""><code>url</code></td>
-<td class=" default"><div>Web page URL of the image to process (URL encoded)</div></td>
-</tr>
+Use the `fields` argument to return optional fields in the JSON response. The default fields will always be returned. For nested arrays, use parentheses to retrieve specific fields, or `*` to return all sub-fields.
 
-<tr>
-<td colspan="2" class="header">Optional arguments</td>
-</tr>
-<tr>
-<td class=""><code>fields</code></td>
-<td class=" optional"><div>Used to specify optional fields to be returned by the Image API. See the <a href="#fields">Fields</a> section below.</div></td>
-</tr>
-<tr>
-<td class=""><code>timeout</code></td>
-<td class=" optional"><div>Sets a value in milliseconds to wait for the retrieval/fetch of content from the requested URL. The default timeout for the third-party response is 30 seconds (30000).</div></td>
-</tr>
-<tr>
-<td class=""><code>callback</code></td>
-<td class=" optional"><div>Use for jsonp requests. Needed for cross-domain ajax.</div></td>
-</tr>
-</table>
-<!--{endarguments}-->
+For example, to return `meta` (in addition to the default fields), your `&fields` argument would be:
 
-<h4 id="fields">The fields argument</h4>
-<p>Use the <code>fields</code> argument to return optional fields in the JSON response. The default fields will always be returned. For nested arrays, use parentheses to retrieve specific fields, or <code>*</code> to return all sub-fields.</p>
-<p>For example, to return <code>meta</code> (in addition to the default fields), your &amp;fields argument would be:</p>
-  
-
-```text
-&amp;fields=meta
+```plaintext
+&fields=meta
 ```
 
+## Response
 
-<h3 id="response">Response</h3>
-<p>The Image API returns data in JSON format.</p>
-<p>Each V3 response includes a <code>request</code> object (which returns request-specific metadata), and an <code>objects</code> array, which will include the extracted information for all images on a submitted page.</p>
-<p>Objects in the Image API's <code>objects</code> array will include the following fields:</p>
+The Image API returns data in JSON format.
 
-<!--{fields}--><table class="controls table table-bordered" id="fields" border="0" cellpadding="5">
-<thead><tr>
-<th>Field</th>
-<th>Description</th>
-</tr></thead>
+Each V3 response includes a `request` object (which returns request-specific metadata), and an `objects` array, which will include the extracted information for all images on a submitted page.
 
-<tr>
-<td class=""><code>type</code></td>
-<td class=" default"><div>Type of object (always <code>image</code>).</div></td>
-</tr>
-<tr>
-<td class=""><code>url</code></td>
-<td class=" default"><div>Direct link to image file.</div></td>
-</tr>
-<tr>
-<td class=""><code>title</code></td>
-<td class=" default"><div>Title or caption of the image, if available.</div></td>
-</tr>
-<tr>
-<td class=""><code>naturalHeight</code></td>
-<td class=" default"><div>Raw image height, in pixels.</div></td>
-</tr>
-<tr>
-<td class=""><code>naturalWidth</code></td>
-<td class=" default"><div>Raw image width, in pixels.</div></td>
-</tr>
-<tr>
-<td class=""><code>humanLanguage</code></td>
-<td class=" default"><div>Returns the (spoken/human) language of the submitted page, using two-letter <a href="http://en.wikipedia.org/wiki/List_of_ISO_639-1_codes" target="_blank">ISO 639-1 nomenclature</a>.</div></td>
-</tr>
-<tr>
-<td class=""><code>anchorUrl</code></td>
-<td class=" default"><div>If the image is hyperlinked, returns the destination URL.</div></td>
-</tr>
-<tr>
-<td class=""><code>pageUrl</code></td>
-<td class=" default"><div>URL of submitted page / page from which the image is extracted.</div></td>
-</tr>
-<tr>
-<td class=""><code>resolvedPageUrl</code></td>
-<td class=" default"><div>Returned if the <code>pageUrl</code> redirects to another URL.</div></td>
-</tr>
-<tr>
-<td class=""><code>xpath</code></td>
-<td class=" default"><div>XPath expression identifying the image node.</div></td>
-</tr>
-<tr>
-<td class=""><code>diffbotUri</code></td>
-<td class=" default"><div>Unique object ID. The <code>diffbotUri</code> is generated from the values of various Image fields and uniquely identifies the object. This can be used for deduplication.</div></td>
-</tr>
+Objects in the Image API's `objects` array will include the following fields:
 
-<tr>
-<td colspan="2" class="header">Optional fields, available using <code>fields=</code> argument</td>
-</tr>
-<tr>
-<td class=""><code>displayHeight</code></td>
-<td class=" optional"><div>Height of image as presented in the browser (and as sized via browser/CSS, if resized).</div></td>
-</tr>
-<tr>
-<td class=""><code>displayWidth</code></td>
-<td class=" optional"><div>Width of image as presented in the browser (and as sized via browser/CSS, if resized).</div></td>
-</tr>
-<tr>
-<td class=""><code>links</code></td>
-<td class=" optional"><div>Returns a top-level object (<code>links</code>) containing all hyperlinks found on the page.</div></td>
-</tr>
-<tr>
-<td class=""><code>meta</code></td>
-<td class=" optional"><div>Comma-separated list of image-embedded metadata (e.g., EXIF, XMP, ICC Profile), if available within the image file.</div></td>
-</tr>
-<tr>
-<td class=""><code>querystring</code></td>
-<td class=" optional"><div>Returns any key/value pairs present in the URL querystring. Items without a discrete value will be returned as <code>true</code>.</div></td>
-</tr>
-<tr>
-<td class=""><code>breadcrumb</code></td>
-<td class=" optional"><div>Returns a top-level array (<code>breadcrumb</code>) of URLs and link text from page breadcrumbs.</div></td>
-</tr>
-</table>
-<!--{endfields}-->
+| Field | Description |
+| :---- | :---------- |
+| `type` | Type of object (always `image`). |
+| `url` | Direct link to image file. |
+| `title` | Title or caption of the image, if available. |
+| `naturalHeight` | Raw image height, in pixels. |
+| `naturalWidth` | Raw image width, in pixels. |
+| `humanLanguage` | Returns the (spoken/human) language of the submitted page, using two-letter [ISO 639-1 nomenclature](https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes).. |
+| `anchorUrl` | If the image is hyperlinked, returns the destination URL. |
+| `pageUrl` | URL of submitted page / page from which the image is extracted. |
+| `resolvedPageUrl` | Returned if the `pageUrl` redirects to another URL. |
+| `xpath` | XPath expression identifying the image node. |
+| `diffbotUri` | Unique object ID. The `diffbotUri` is generated from the values of various Image fields and uniquely identifies the object. This can be used for deduplication. </td></tr><tr><td colspan="2">**Optional fields, available using `fields=` argument**</td> |
+| `displayHeight` | Height of image as presented in the browser (and as sized via browser/CSS, if resized). |
+| `displayWidth` | Width of image as presented in the browser (and as sized via browser/CSS, if resized). |
+| `links` | Returns a top-level object (`links`) containing all hyperlinks found on the page. |
+| `meta` | Comma-separated list of image-embedded metadata (e.g., EXIF, XMP, ICC Profile), if available within the image file. |
+| `querystring` | Returns any key/value pairs present in the URL querystring. Items without a discrete value will be returned as `true`. |
+| `breadcrumb` | Returns a top-level array (`breadcrumb`) of URLs and link text from page breadcrumbs. |
 
-<h3 id="sampleresponse">Example Response</h3>
-<div class="indent">
-  
+## Example Response
 
-```text
-
+```json
 {
   "request": {
     "pageUrl": "http://www.diffbot.com/products",
@@ -192,51 +103,42 @@ https://api.diffbot.com/v3/image
   ],
 }
 ```
+## Authentication
 
+You can supply Diffbot with basic authentication credentials or custom HTTP headers (see below) to access intranet pages or other sites that require a login.
 
-</div>
+### Basic Authentication
 
-<h3 id="authenticating">Authentication</h3>
-<p>You can supply Diffbot with basic authentication credentials or custom HTTP headers (see below) to access intranet pages or other sites that require a login.</p>
+To access pages that require a login/password (using [basic access authentication](https://en.wikipedia.org/wiki/Basic_access_authentication)), include the username and password in your `url` parameter, e.g.: `url=http%3A%2F%2FUSERNAME:PASSWORD@www.diffbot.com`.
 
-<h4>Basic Authentication</h4>
-<p>To access pages that require a login/password (using <a href="http://en.wikipedia.org/wiki/Basic_access_authentication" target="_blank">basic access authentication</a>), include the username and password in your <code>url</code> parameter, e.g.: <code>url=http%3A%2F%2FUSERNAME:PASSWORD@www.diffbot.com</code>.</p>
+## Custom HTTP Headers
 
-<h3 id="customheaders">Custom HTTP Headers</h3>
-<p>You can supply Diffbot APIs with custom HTTP headers that will be passed along when making requests to third-party sites. These can be used to define specific Referer, User-Agent, Cookie or any other values.</p>
-<p>Custom headers should be sent as HTTP headers in your request to <code>https://api.diffbot.com</code>, and prepended with <code>X-Forward-</code>.</p>
-<p>For instance, to send custom <code>User-Agent</code>, <code>Referer</code> and <code>My-Custom-Header</code> header values:</p>
-<table class="controls table table-bordered" border="0" cellpadding="5">
-<thead><tr>
-<th>Desired Header</th>
-<th>Send to api.diffbot.com</th>
-</tr></thead>
-<tbody>
-<tr>
-<td><code>User-Agent:Diffbot</code></td>
-<td><code>X-Forward-User-Agent:Diffbot</code></td>
-</tr>
-<tr>
-<td><code>Referer:diffbot.com</code></td>
-<td><code>X-Forward-Referer:diffbot.com</code></td>
-</tr>
-<tr>
-<td><code>My-Custom-Header:CustomValue</code></td>
-<td><code>X-Forward-My-Custom-Header:CustomValue</code></td>
-</tr>
-</tbody>
-</table>
+You can supply Diffbot APIs with custom HTTP headers that will be passed along when making requests to third-party sites. These can be used to define specific Referer, User-Agent, Cookie or any other values.
 
-<h3 id="x-evaluate">Custom Javascript</h3>
+Custom headers should be sent as HTTP headers in your request to `https://api.diffbot.com`, and prepended with `X-Forward-`.
+
+For instance, to send custom `User-Agent`, `Referer` and `My-Custom-Header` header values:
+
+| Desired Header | Send to api.diffbot.com |
+| :-- | :-- |
+| `User-Agent:Diffbot` | `X-Forward-User-Agent:Diffbot` |
+| `Referer:diffbot.com` | `X-Forward-Referer:diffbot.com` |
+| `My-Custom-Header:CustomValue` | `X-Forward-My-Custom-Header:CustomValue` |
+
+## Custom Javascript
+
 <div class="alert">This functionality is currently in beta.</div>
-<p>Using the <code>X-Evaluate</code> custom header (sent as <code>X-Forward-X-Evaluate</code>), you can inject your own Javascript code into web pages. Custom Javascript will be executed once the DOM has loaded.</p>
-<p>Custom Javascript should be provided as a text string and contained in its own function. You must also include the special functions <code>start()</code> and <code>end()</code> to indicate the beginning and end of your custom script. Once <code>end()</code> fires, the updated document will be processed by your chosen extraction API.</p>
-<p>It's recommended that your <code>end()</code> function be offset using <code>setTimeout</code> (see <a href="http://www.w3schools.com/js/js_timing.asp" target="_blank">JavaScript Timing Events</a>) in order to accommodate your primary function processing. Additionally, if your custom Javascript requires access to Ajax-delivered content, it may be necessary to offset your entire function using <code>setTimeout</code> in order to delay the start of your processing.</p>
-<p>The following sample <code>X-Evaluate</code> header waits one-half second after the DOM has loaded, enacts a click on the <code>a.loadMore</code> element, then waits 800 milliseconds before signaling the <code>end()</code>:</p>
+
+Using the `X-Evaluate` custom header (sent as `X-Forward-X-Evaluate`), you can inject your own Javascript code into web pages. Custom Javascript will be executed once the DOM has loaded.
+
+Custom Javascript should be provided as a text string and contained in its own function. You must also include the special functions `start()` and `end()` to indicate the beginning and end of your custom script. Once `end()` fires, the updated document will be processed by your chosen extraction API.
+
+It's recommended that your `end()` function be offset using `setTimeout` (see [JavaScript Timing Events](https://www.w3schools.com/js/js_timing.asp)) in order to accommodate your primary function processing. Additionally, if your custom Javascript requires access to Ajax-delivered content, it may be necessary to offset your entire function using `setTimeout` in order to delay the start of your processing.
+
+The following sample `X-Evaluate` header waits one-half second after the DOM has loaded, enacts a click on the `a.loadMore` element, then waits 800 milliseconds before signaling the `end()`:
 
 
-```text
-
+```js
 function() {
     start();
     setTimeout(function() {
@@ -251,41 +153,28 @@ function() {
         }
     }, 500);
 }
-
 ```
 
+Delivered as a string value as a custom header:
 
-
-<p>Delivered as a string value as a custom header:</p>
-
-
-```text
+```json
 "X-Forward-X-Evaluate": "function() {start();setTimeout(function(){var loadMoreNode=document.querySelector('a.loadMore');if (loadMoreNode != null) {loadMoreNode.click();setTimeout(function(){end();}, 800);} else {end();}},500);}"
 ```
 
+## Posting Content
 
+If your content is not publicly available (e.g., behind a firewall), you can POST markup directly to the Image API endpoint for analysis:
 
-<h3 id="posting">Posting Content</h3>
-<p>If your content is not publicly available (e.g., behind a firewall), you can POST markup directly to the Image API endpoint for analysis:
-</p>
-
-
-```text
-https://api.diffbot.com/v3/image?token=...&amp;url=...
+```plaintext
+https://api.diffbot.com/v3/image?token=...&url=...
 ```
 
+Please note that the `url` argument is still required, and will be used to resolve any relative links contained in the markup.
 
-<p>Please note that the <code>url</code> argument is still required, and will be used to resolve any relative links contained in the markup.</p>
-<p>Provide the content to analyze as your POST body, and specify the <code>Content-Type</code> header as <code>text/html</code>.</p>
-<p><strong>HTML Post Sample</strong>:</p>
-  
+Provide the content to analyze as your POST body, and specify the `Content-Type` header as `text/html`.
 
-```text
+### HTML Post Sample
 
-curl -H "Content-Type: text/html" -d '&lt;html&gt;&lt;body&gt;&lt;h2&gt;Diffy the Robot&lt;/h2&gt;&lt;div&gt;&lt;img src="diffy-b.png"&gt;&lt;/div&gt;&lt;/body&gt;&lt;/html&gt;' 'https://api.diffbot.com/v3/image?token=...&amp;url=http%3A%2F%2Fwww.diffbot.com'
+```plaintext
+curl -H "Content-Type: text/html" -d '<html><body><h2>Diffy the Robot</h2><div><img src="diffy-b.png"></div></body></html>' 'https://api.diffbot.com/v3/image?token=...&url=http%3A%2F%2Fwww.diffbot.com'
 ```
-
-
-
-
-</div>

--- a/docs/api-managing-rules-programmatically.md
+++ b/docs/api-managing-rules-programmatically.md
@@ -6,139 +6,68 @@ todo: Modify links to old Dashboard
 todo: Modify links to old API docs
 ---
 
-<div id="docBody">
-<p>You can manage your Custom API using our Custom Rule Management API.</p>
+You can manage your Custom API using our Custom Rule Management API.
 
-<h3 id="request">Retrieving Existing Rules</h3>
-<p>To retrieve your existing rules, perform a HTTP GET request on the following endpoint:</p>
+## Retrieving Existing Rules
 
+To retrieve your existing rules, perform a HTTP GET request on the following endpoint:
 
-```text
+```plaintext
 https://api.diffbot.com/v3/custom
 ```
 
+Provide the following arguments:
 
-<p>Provide the following arguments:</p>
-<table class="controls table table-bordered" id="arguments" border="0" cellpadding="5">
-<thead><tr>
-<th>Argument</th>
-<th>Description</th>
-</tr></thead>
+| Argument | Description |
+| :------- | :---------- |
+| `token` | Developer token |
 
-<tr>
-<td class=""><code>token</code></td>
-<td class=" default"><div>Developer token</div></td>
-</tr>
-</table>
+This returns a JSON-formatted ruleset which corresponds to the UI elements of the <a href="/dev/customize">Custom API Toolkit</a>.
 
+| Field | Description |
+| :---- | :---------- |
+| `urlPattern` | Regular expression used to match URLs to the appropriate rule. |
+| `api` | Diffbot API against which the ruleset should be appled. The `api` value should include the `/api/` string, e.g. `/api/article`. |
+| `rules` | An array of rules applying to individual fields of the Diffbot API. The `rules` array can be empty (`rules=[]`), but the field must be included in API requests. |
+| &#x21B3;`name` | Field to correct (e.g., `title`) or add (e.g., `customCategory`). |
+| &#x21B3;`selector` | CSS selector to find the appropriate content on the page. |
+| &#x21B3;`value` | Optional: a specific value to hard-code, in lieu of a selector. |
+| &#x21B3;`filters` | Optional: additional options to replace content, ignore selectors, or extract HTML attribute values. See below. </td></tr><tr><td colspan="2">**Optional arguments:**</td> |
+| `testUrl` | A sample URL used to preview your rule within the <a href="/dev/customize">Custom API Toolkit</a>. |
+| `prefilters` | An array of selectors that should be completely dropped from the DOM. These selectors will be fully ignored by all Diffbot processing. |
+| `renderOptions` | Querystring arguments to be passed to the Diffbot rendering engine, e.g. `wait=5000`. |
+| `xForwardHeaders` | An object containing any custom headers to be passed along in all requests to URLs matching the `urlPattern`. Header values can either be a single string, or an array of strings (from which one will be selected at request-time). Custom headers can include:
+| &#x21B3;`User-Agent` | User agent to use in place of Diffbot default. |
+| &#x21B3;`Referer` | Custom referer to use in place of Diffbot default. |
+| &#x21B3;`Cookie` | Custom cookie content to be sent with all requests. |
+| &#x21B3;`Accept-Language` | Custom accept-language header to be sent. |
+| &#x21B3;`X-Evaluate` | Custom Javascript to be executed at render-time. See [Custom Javascript](#custom-javascript) below. |
 
-<p>This returns a JSON-formatted ruleset which corresponds to the UI elements of the <a href="/dev/customize">Custom API Toolkit</a>.</p>
+Rules for nested arrays (e.g., `images` or `videos` in the [Article API](api-article.md), or `products` in the [Product API](api-product.md)) should be nested within the `rules` object.
 
-<table class="controls table table-bordered" border="0" cellpadding="5">
-<thead><tr>
-<th>Field</th>
-<th>Description</th>
-</tr></thead>
-<tbody>
-<tr>
-<td><code>urlPattern</code></td>
-<td>Regular expression used to match URLs to the appropriate rule.</td>
-</tr>
-<tr>
-<td><code>api</code></td>
-<td>Diffbot API against which the ruleset should be appled. The <code>api</code> value should include the <code>/api/</code> string, e.g. <code>/api/article</code>.</td>
-</tr>
-<tr>
-<td><code>rules</code></td>
-<td>An array of rules applying to individual fields of the Diffbot API. The <code>rules</code> array can be empty (<code>rules=[]</code>), but the field must be included in API requests.</td>
-</tr>
-<tr>
-<td class="tags indent"><code>name</code></td>
-<td class="indent">Field to correct (e.g., <code>title</code>) or add (e.g., <code>customCategory</code>).</td>
-</tr>
-<tr>
-<td class="tags indent"><code>selector</code></td>
-<td class="indent">CSS selector to find the appropriate content on the page.</td>
-</tr>
-<tr>
-<td class="tags indent"><code>value</code></td>
-<td class="indent">Optional: a specific value to hard-code, in lieu of a selector.</td>
-</tr>
-<tr>
-<td class="tags indent"><code>filters</code></td>
-<td class="indent">Optional: additional options to replace content, ignore selectors, or extract HTML attribute values. See below.</td>
-</tr>
-<tr><td colspan="2"><strong>Optional arguments:</strong></td></tr>
-<tr>
-<td><code>testUrl</code></td>
-<td>A sample URL used to preview your rule within the <a href="/dev/customize">Custom API Toolkit</a>.</td>
-</tr>
-<tr>
-<td><code>prefilters</code></td>
-<td>An array of selectors that should be completely dropped from the DOM. These selectors will be fully ignored by all Diffbot processing.</td>
-</tr>
-<tr>
-<td><code>renderOptions</code></td>
-<td>Querystring arguments to be passed to the Diffbot rendering engine, e.g. <code>wait=5000</code>.</td>
-</tr>
-<tr>
-<td><code>xForwardHeaders</code></td>
-<td>An object containing any custom headers to be passed along in all requests to URLs matching the <code>urlPattern</code>. Header values can either be a single string, or an array of strings (from which one will be selected at request-time). Custom headers can include:</td>
-</tr>
-<tr>
-<td class="tags indent"><code>User-Agent</code></td>
-<td class="indent">User agent to use in place of Diffbot default.</td>
-</tr>
-<tr>
-<td class="tags indent"><code>Referer</code></td>
-<td class="indent">Custom referer to use in place of Diffbot default.</td>
-</tr>
-<tr>
-<td class="tags indent"><code>Cookie</code></td>
-<td class="indent">Custom cookie content to be sent with all requests.</td>
-</tr>
-<tr>
-<td class="tags indent"><code>Accept-Language</code></td>
-<td class="indent">Custom accept-language header to be sent.</td>
-</tr>
-<tr>
-<td class="tags indent"><code>X-Evaluate</code></td>
-<td class="indent">Custom Javascript to be executed at render-time. See <a href="#x-evaluate">Custom Javascript</a> below.</td>
-</tr>
+### Rule Filters (Optional)
 
-</tbody>
-</table>
+A rule's `filters` element can contain multiple entries, which correspond to the filters within the API Toolkit. Each filter should contain:
 
-<p>Rules for nested arrays (e.g., <code>images</code> or <code>videos</code> in the <a href="api-article">Article API</a>, or <code>products</code> in the <a href="api-product">Product API</a>) should be nested within the <code>rules</code> object.</p>
+| Field | Description |
+| :---- | :---------- |
+| `type` | Type of filter, either `replace`, `exclude` (ignore), or `attribute`. |
+| `args` | Argument(s) to be used for the filter. If you are replacing content, your `args` should be a comma-separated list of the regular expression to search for and the expression to replace with. If you are excluding content, your `args` should enumerate the CSS selector(s) to ignore. If you are attempting to retrieve an HTML attribute, specify the attribute (e.g. `src`) in your `args` value. |
 
-<h4>Rule Filters (Optional)</h4>
-<p>A rule's <code>filters</code> element can contain multiple entries, which correspond to the filters within the API Toolkit. Each filter should contain:</p>
+### Custom Javascript
 
-<table class="controls table table-bordered" border="0" cellpadding="5">
-<thead><tr>
-<th>Field</th>
-<th>Description</th>
-</tr></thead>
-<tbody>
-<tr>
-<td><code>type</code></td>
-<td>Type of filter, either <code>replace</code>, <code>exclude</code> (ignore), or <code>attribute</code>.</td>
-</tr>
-<tr>
-<td><code>args</code></td>
-<td>Argument(s) to be used for the filter. If you are replacing content, your <code>args</code> should be a comma-separated list of the regular expression to search for and the expression to replace with. If you are excluding content, your <code>args</code> should enumerate the CSS selector(s) to ignore. If you are attempting to retrieve an HTML attribute, specify the attribute (e.g. <code>src</code>) in your <code>args</code> value.</td>
-</tr>
-</tbody>
-</table>
-<h4 id="x-evaluate">Custom Javascript</h4>
-<p>Using the <code>X-Evaluate</code> custom header, you can inject your own Javascript code into web pages. Custom Javascript will be executed once the DOM has loaded.</p>
-<p>Your custom Javascript should be provided as a text string and contained in its own function. You must also include the special functions <code>start()</code> and <code>end()</code> to indicate the beginning and end of your custom script. Once <code>end()</code> fires, the updated document will be processed by your chosen extraction API.</p>
-<p>It's recommended that your <code>end()</code> function be offset using <code>setTimeout</code> (see <a href="http://www.w3schools.com/js/js_timing.asp" target="_blank">JavaScript Timing Events</a>) in order to accommodate your primary function processing. Additionally, if your custom Javascript requires access to Ajax-delivered content, it may be necessary to offset your entire function using <code>setTimeout</code> in order to delay the start of your processing.</p>
-<p>The following sample <code>X-Evaluate</code> header waits one-half second after the DOM has loaded, enacts a click on the <code>a.loadMore</code> element, then waits 800 milliseconds before signaling the <code>end()</code>:</p>
+<div class="alert">This functionality is currently in beta.</div>
+
+Using the `X-Evaluate` custom header (sent as `X-Forward-X-Evaluate`), you can inject your own Javascript code into web pages. Custom Javascript will be executed once the DOM has loaded.
+
+Custom Javascript should be provided as a text string and contained in its own function. You must also include the special functions `start()` and `end()` to indicate the beginning and end of your custom script. Once `end()` fires, the updated document will be processed by your chosen extraction API.
+
+It's recommended that your `end()` function be offset using `setTimeout` (see [JavaScript Timing Events](https://www.w3schools.com/js/js_timing.asp)) in order to accommodate your primary function processing. Additionally, if your custom Javascript requires access to Ajax-delivered content, it may be necessary to offset your entire function using `setTimeout` in order to delay the start of your processing.
+
+The following sample `X-Evaluate` header waits one-half second after the DOM has loaded, enacts a click on the `a.loadMore` element, then waits 800 milliseconds before signaling the `end()`:
 
 
-```text
-
+```js
 function() {
     start();
     setTimeout(function() {
@@ -153,31 +82,21 @@ function() {
         }
     }, 500);
 }
-
 ```
 
+Delivered as a rule:
 
-
-<p>Delivered as a rule:</p>
-
-
-```text
+```json
 "xForwardHeaders": {
    "X-Evaluate": "function() {start();setTimeout(function(){var loadMoreNode=document.querySelector('a.loadMore');if (loadMoreNode != null) {loadMoreNode.click();setTimeout(function(){end();}, 800);} else {end();}},500);}"
 }
 ```
 
+## Sample Ruleset
 
+The following ruleset JSON gives an example of many of the fields and functionality described above.
 
-<hr>
-
-<h3>Sample Ruleset</h3>
-<p>The following ruleset JSON gives an example of many of the fields and functionality described above.</p>
-
-
-
-```text
-
+```json
 {
     "urlPattern": "(http(s)?://)?(.*\\.)?support.diffbot.com.*",
     "testUrl": "http://support.diffbot.com/crawlbot/using-zapier-with-crawlbot-or-bulk-api-jobs/",
@@ -191,7 +110,7 @@ function() {
       ],
       "Referer": "http://www.diffbot.com",
       "User-Agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_9_3) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/35.0.1916.153 Safari/537.36"
-    }
+    },
     "rules": [
     {
       "selector": ".entry-content p",
@@ -224,64 +143,42 @@ function() {
 
 ```
 
+The above:
 
-<p>The above:</p>
-<ul>
-<li>Specifies a URL pattern regular expression that matches *.support.diffbot.com</li>
-<li>Includes a <code>testUrl</code> -- for preview in the Custom API UI.</li>
-<li>Specifies the API (<code>/api/article</code>).</li>
-<li>Then, within the <code>rules</code> object:
-<ul>
-<li>A simple selector to override the <code>text</code> (and <code>html</code>) field.</li>
-<li>A selector for the <code>images</code> parent container, with its own sub-array of rules for individual images.</li>
-<li>A filter on the specific image <code>url</code> field to retrieve the elements <code>src</code> attribute.</li>
-</ul>
-</li>
-</ul>
-<hr>
-<h3>Creating or Updating Rules</h3>
+- Specifies a URL pattern regular expression that matches *.support.diffbot.com
+- Includes a `testUrl` -- for preview in the Custom API UI.
+- Specifies the API (`/api/article`).
+- Then, within the `rules` object:
+    - A simple selector to override the `text` (and `html`) field.
+    - A selector for the `images` parent container, with its own sub-array of rules for individual images.
+    - A filter on the specific image `url` field to retrieve the elements `src` attribute.
 
-<p>An individual rule is determined by a unique <code>urlPattern</code> and <code>api</code> combination. Create or update rules by POSTing to the following endpoint:
+## Creating or Updating Rules
 
-</p>
+An individual rule is determined by a unique `urlPattern` and `api` combination. Create or update rules by POSTing to the following endpoint:
 
-
-```text
+```plaintext
 https://api.diffbot.com/v3/custom
 ```
 
+Append the following querystring arguments to your POST URL:
 
+| Argument | Description |
+| :------- | :---------- |
+| `token` | Developer token </td></tr><tr><td colspan="2">**Optional arguments**</td> |
+| `replace` | Hash code of a single ruleset to update. This allows you to update an existing rule's API or `urlPattern` without adding a new set. |
 
-<p>Append the following querystring arguments to your POST URL:</p>
+Your POST body should either contain a JSON array of JSON objects -- corresponding to the above fields -- or a single JSON object.
 
-<table class="controls table table-bordered" id="arguments" border="0" cellpadding="5">
-<thead><tr>
-<th>Argument</th>
-<th>Description</th>
-</tr></thead>
-<tr>
-<td class=""><code>token</code></td>
-<td class=" default"><div>Developer token</div></td>
-</tr>
-<tr>
-<td colspan="2" class="header">Optional arguments</td>
-</tr>
-<tr>
-<td class=""><code>replace</code></td>
-<td class=" default"><div>Hash code of a single ruleset to update. This allows you to update an existing rule's API or <code>urlPattern</code> without adding a new set.</div></td>
-</tr>
-</table>
+To update or add a single ruleset, send a single JSON object. This will add the new ruleset to your token's rules (or update an existing  `urlPattern` and `api` pair). To update a ruleset while changing either the `api` or `urlPattern`, send that ruleset's hashcode, as returned from the ruleset's last update.
 
-<p>Your POST body should either contain a JSON array of JSON objects -- corresponding to the above fields -- or a single JSON object.</p>
-<p>To update or add a single ruleset, send a single JSON object. This will add the new ruleset to your token's rules (or update an existing  <code>urlPattern</code> and <code>api</code> pair). To update a ruleset while changing either the <code>api</code> or <code>urlPattern</code>, send that ruleset's hashcode, as returned from the ruleset's last update.</p>
-<p>To update/overwrite all rules for your token, send a JSON array of objects. This will replace all rulesets for your token.</p>
+To update/overwrite all rules for your token, send a JSON array of objects. This will replace all rulesets for your token.
 
-<h4 id="response">Response
-</h4>
-<p>Updating or creating rules will return a JSON response containing an array of <code>hashes</code>. These hashes represent each of your updated or created rules, and can be used to update individual rules.</p>
+### Response
 
+Updating or creating rules will return a JSON response containing an array of `hashes`. These hashes represent each of your updated or created rules, and can be used to update individual rules.
 
-```text
+```json
 {
   "hashes":
     [
@@ -291,7 +188,3 @@ https://api.diffbot.com/v3/custom
     ]
 }
 ```
-
-
-
-</div>

--- a/docs/api-product-categories.md
+++ b/docs/api-product-categories.md
@@ -4,61 +4,29 @@ title: Product API: Category Taxonomy
 sidebar_label: Product API: Category Taxonomy
 ---
 
-<div id="docBody">
+Diffbot will automatically infer the category of extracted products in the `category` field. The most appropriate single value will be returned from the following list:
 
-
-<div class="tabbable">
-
-
-
-<div class="tab-content">
-<div class="tab-pane active" id="v3">
-<p>Diffbot will automatically infer the category of extracted products in the <code>category</code> field. The most appropriate single value will be returned from the following list:</p>
-            
-
-
-<table class="controls table table-bordered" id="fields" border="0" cellpadding="5">
-
-<tbody>
-<tr><td class="">Appliances</td></tr>
-<tr><td class="">Auto Parts</td></tr>
-<tr><td class="">Babies &amp; Kids</td></tr>
-<tr><td class="">Cameras</td></tr>
-<tr><td class="">Clothing</td></tr>
-<tr><td class="">Computers</td></tr>
-<tr><td class="">Electronics</td></tr>
-<tr><td class="">Flowers &amp; Gifts</td></tr>
-<tr><td class="">Furniture</td></tr>
-<tr><td class="">Grocery &amp; Gourmet</td></tr>
-<tr><td class="">Health &amp; Beauty</td></tr>
-<tr><td class="">Home Improvement</td></tr>
-<tr><td class="">Indoor Living</td></tr>
-<tr><td class="">Industrial Supply</td></tr>
-<tr><td class="">Jewelry &amp; Watches</td></tr>
-<tr><td class="">Magazines</td></tr>
-<tr><td class="">Mature</td></tr>
-<tr><td class="">Musical Instruments</td></tr>
-<tr><td class="">Office</td></tr>
-<tr><td class="">Pets</td></tr>
-<tr><td class="">Software</td></tr>
-<tr><td class="">Sporting Goods</td></tr>
-<tr><td class="">Toys</td></tr>
-<tr><td class="">Video Games</td></tr>
-
-</tbody>
-</table>
-
-</div>
-
-
-</div>
-
-
-</div>
-
-
-
-
-
-
-</div>
+- Appliances
+- Auto Parts
+- Babies & Kids
+- Cameras
+- Clothing
+- Computers
+- Electronics
+- Flowers & Gifts
+- Furniture
+- Grocery & Gourmet
+- Health & Beauty
+- Home Improvement
+- Indoor Living
+- Industrial Supply
+- Jewelry & Watches
+- Magazines
+- Mature
+- Musical Instruments
+- Office
+- Pets
+- Software
+- Sporting Goods
+- Toys
+- Video Games

--- a/docs/api-product-normalized-specs.md
+++ b/docs/api-product-normalized-specs.md
@@ -4,47 +4,21 @@ title: Product API: Normalized Specs
 sidebar_label: Product API: Normalized Specs
 ---
 
-<div id="docBody">
+The `normalizedSpecs` field returns a product's automatically standardized/sanitized specifications, if a specs table and/or similar elements are detected on a page. Numeric values for many specifications are normalized into a standard units.
 
+## Data Returned
 
-<div class="tabbable">
+Each key will return an array of values. Single-value specifications will contain a single-element array. For each value, the following possible fields will be returned:
 
+| Field | Description |
+| :---- | :---------- |
+| `cleanLiteral` | A sanitized version of the text string. |
+| `unit` | Normalized output unit, if applicable, per below table. |
+| `value` | Normalized output value, if applicable, according to the `unit`. |
 
+## Example Response
 
-<div class="tab-content">
-<div class="tab-pane active" id="v3">
-<p>The <code>normalizedSpecs</code> field returns a product's automatically standardized/sanitized specifications, if a specs table and/or similar elements are detected on a page. Numeric values for many specifications are normalized into a standard units.</p>
-<h3 id="request">Data Returned</h3>
-
-<p>Each key will return an array of values. Single-value specifications will contain a single-element array. For each value, the following possible fields will be returned:</p>
-
-<table class="controls table table-bordered" id="fields" border="0" cellpadding="5">
-<thead><tr>
-<th>Field</th>
-<th>Description</th>
-</tr></thead>
-
-<tbody>
-<tr>
-<td class=""><code>cleanLiteral</code></td>
-<td class=" default"><div>A sanitized version of the text string.</div></td>
-</tr>
-<tr>
-<td class=""><code>unit</code></td>
-<td class=" default"><div>Normalized output unit, if applicable, per below table.</div></td>
-</tr>
-<tr>
-<td class=""><code>value</code></td>
-<td class=" default"><div>Normalized output value, if applicable, according to the <code>unit</code>.</div></td>
-</tr>
-</tbody>
-</table>
-
-<h3 id="sampleresponse">Example Response</h3>
-<div class="indent">
-  
-
-```text
+```json
 "normalizedSpecs_beta": {
   "color": [
     {
@@ -99,517 +73,104 @@ sidebar_label: Product API: Normalized Specs
 }
 ```
 
+## List of Normalized Keys
 
-</div>
-
-<h3>List of Normalized Keys</h3>
-
-<table class="controls table table-bordered" border="0" cellpadding="5">
-<thead>
-<tr>
-<th>Normalized Key</th>
-<th>Type</th>
-<th>Normalized Value Unit</th>
-</tr>
-</thead>
-<tr>
-<td><code>armLength</code></td>
-<td>numeric</td>
-<td>meter</td>
-</tr>
-<tr>
-<td><code>audioJackDiameter</code></td>
-<td>numeric</td>
-<td>meter</td>
-</tr>
-<tr>
-<td><code>batteryCapacity</code></td>
-<td>numeric</td>
-<td>coulomb</td>
-</tr>
-<tr>
-<td><code>bookFormat</code></td>
-<td>string</td>
-<td>n/a</td>
-</tr>
-<tr>
-<td><code>brand</code></td>
-<td>string</td>
-<td>n/a</td>
-</tr>
-<tr>
-<td><code>busClockFrequency</code></td>
-<td>numeric</td>
-<td>hertz</td>
-</tr>
-<tr>
-<td><code>bust</code></td>
-<td>numeric</td>
-<td>meter</td>
-</tr>
-<tr>
-<td><code>dataCapacity</code></td>
-<td>numeric</td>
-<td>kilobyte</td>
-</tr>
-<tr>
-<td><code>chest</code></td>
-<td>numeric</td>
-<td>meter</td>
-</tr>
-<tr>
-<td><code>circumference</code></td>
-<td>numeric</td>
-<td>meter</td>
-</tr>
-<tr>
-<td><code>clockFrequency</code></td>
-<td>numeric</td>
-<td>hertz</td>
-</tr>
-<tr>
-<td><code>color</code></td>
-<td>string</td>
-<td>rgb hex value</td>
-</tr>
-<tr>
-<td><code>condition</code></td>
-<td>string</td>
-<td>n/a</td>
-</tr>
-<tr>
-<td><code>copyingSpeed</code></td>
-<td>numeric</td>
-<td>pageperminute</td>
-</tr>
-<tr>
-<td><code>cordLength</code></td>
-<td>numeric</td>
-<td>meter</td>
-</tr>
-<tr>
-<td><code>countryOfOrigin</code></td>
-<td>string</td>
-<td>n/a</td>
-</tr>
-<tr>
-<td><code>dataReadSpeed</code></td>
-<td>numeric</td>
-<td>kilobytepersecond</td>
-</tr>
-<tr>
-<td><code>dataTransmissionSpeed</code></td>
-<td>numeric</td>
-<td>kilobytepersecond</td>
-</tr>
-<tr>
-<td><code>dataWriteSpeed</code></td>
-<td>numeric</td>
-<td>kilobytepersecond</td>
-</tr>
-<tr>
-<td><code>depth</code></td>
-<td>numeric</td>
-<td>meter</td>
-</tr>
-<tr>
-<td><code>diameter</code></td>
-<td>numeric</td>
-<td>meter</td>
-</tr>
-<tr>
-<td><code>fileSize</code></td>
-<td>numeric</td>
-<td>kilobyte</td>
-</tr>
-<tr>
-<td><code>focalLength</code></td>
-<td>numeric</td>
-<td>meter</td>
-</tr>
-<tr>
-<td><code>fuelConsumptionCity</code></td>
-<td>numeric</td>
-<td>literperkilometer</td>
-</tr>
-<tr>
-<td><code>fuelConsumptionCombined</code></td>
-<td>numeric</td>
-<td>literperkilometer</td>
-</tr>
-<tr>
-<td><code>fuelConsumptionHighway</code></td>
-<td>numeric</td>
-<td>literperkilometer</td>
-</tr>
-<tr>
-<td><code>gender</code></td>
-<td>string</td>
-<td>n/a</td>
-</tr>
-<tr>
-<td><code>genre</code></td>
-<td>string</td>
-<td>n/a</td>
-</tr>
-<tr>
-<td><code>gpuFrequencyClock</code></td>
-<td>numeric</td>
-<td>hertz</td>
-</tr>
-<tr>
-<td><code>heel</code></td>
-<td>numeric</td>
-<td>meter</td>
-</tr>
-<tr>
-<td><code>height</code></td>
-<td>numeric</td>
-<td>meter</td>
-</tr>
-<tr>
-<td><code>hips</code></td>
-<td>numeric</td>
-<td>meter</td>
-</tr>
-<tr>
-<td><code>impedance</code></td>
-<td>numeric</td>
-<td>OHM</td>
-</tr>
-<tr>
-<td><code>inkColor</code></td>
-<td>string</td>
-<td>n/a</td>
-</tr>
-<tr>
-<td><code>innerDiameter</code></td>
-<td>numeric</td>
-<td>meter</td>
-</tr>
-<tr>
-<td><code>inputVoltage</code></td>
-<td>numeric</td>
-<td>volt</td>
-</tr>
-<tr>
-<td><code>inseam</code></td>
-<td>numeric</td>
-<td>meter</td>
-</tr>
-<tr>
-<td><code>language</code></td>
-<td>string</td>
-<td>n/a</td>
-</tr>
-<tr>
-<td><code>length</code></td>
-<td>numeric</td>
-<td>meter</td>
-</tr>
-<tr>
-<td><code>lensDiameter</code></td>
-<td>numeric</td>
-<td>meter</td>
-</tr>
-<tr>
-<td><code>lensWidth</code></td>
-<td>numeric</td>
-<td>meter</td>
-</tr>
-<tr>
-<td><code>material</code></td>
-<td>string</td>
-<td>n/a</td>
-</tr>
-<tr>
-<td><code>maxFocalLength</code></td>
-<td>numeric</td>
-<td>meter</td>
-</tr>
-<tr>
-<td><code>maxFrequencyResponse</code></td>
-<td>numeric</td>
-<td>hertz</td>
-</tr>
-<tr>
-<td><code>maxWeight</code></td>
-<td>numeric</td>
-<td>kilogram</td>
-</tr>
-<tr>
-<td><code>maxWeightCapacity</code></td>
-<td>numeric</td>
-<td>kilogram</td>
-</tr>
-<tr>
-<td><code>maxOperatingTemperature</code></td>
-<td>numeric</td>
-<td>celsius</td>
-</tr>
-<tr>
-<td><code>maxStorageTemperature</code></td>
-<td>numeric</td>
-<td>celsius</td>
-</tr>
-<tr>
-<td><code>memoryClockFrequency</code></td>
-<td>numeric</td>
-<td>hertz</td>
-</tr>
-<tr>
-<td><code>mileage</code></td>
-<td>numeric</td>
-<td>meter</td>
-</tr>
-<tr>
-<td><code>minFocalLength</code></td>
-<td>numeric</td>
-<td>meter</td>
-</tr>
-<tr>
-<td><code>minFrequencyResponse</code></td>
-<td>numeric</td>
-<td>hertz</td>
-</tr>
-<tr>
-<td><code>minWeight</code></td>
-<td>numeric</td>
-<td>kilogram</td>
-</tr>
-<tr>
-<td><code>minWeightCapacity</code></td>
-<td>numeric</td>
-<td>kilogram</td>
-</tr>
-<tr>
-<td><code>minOperatingTemperature</code></td>
-<td>numeric</td>
-<td>celsius</td>
-</tr>
-<tr>
-<td><code>minStorageTemperature</code></td>
-<td>numeric</td>
-<td>celsius</td>
-</tr>
-<tr>
-<td><code>mpn</code></td>
-<td>string</td>
-<td>n/a</td>
-</tr>
-<tr>
-<td><code>neck</code></td>
-<td>numeric</td>
-<td>meter</td>
-</tr>
-<tr>
-<td><code>operating_temperature</code></td>
-<td>numeric</td>
-<td>celsius</td>
-</tr>
-<tr>
-<td><code>opticalWaveLength</code></td>
-<td>numeric</td>
-<td>meter</td>
-</tr>
-<tr>
-<td><code>outerDiameter</code></td>
-<td>numeric</td>
-<td>meter</td>
-</tr>
-<tr>
-<td><code>outputVoltage</code></td>
-<td>numeric</td>
-<td>volt</td>
-</tr>
-<tr>
-<td><code>power</code></td>
-<td>numeric</td>
-<td>watt</td>
-</tr>
-<tr>
-<td><code>powerConsumption</code></td>
-<td>numeric</td>
-<td>watt</td>
-</tr>
-<tr>
-<td><code>powerConsumptionIdle</code></td>
-<td>numeric</td>
-<td>watt</td>
-</tr>
-<tr>
-<td><code>powerDeveloped</code></td>
-<td>numeric</td>
-<td>watt</td>
-</tr>
-<tr>
-<td><code>powerRMS</code></td>
-<td>numeric</td>
-<td>watt</td>
-</tr>
-<tr>
-<td><code>printSpeedBlack</code></td>
-<td>numeric</td>
-<td>pageperminute</td>
-</tr>
-<tr>
-<td><code>printSpeedColor</code></td>
-<td>numeric</td>
-<td>pageperminute</td>
-</tr>
-<tr>
-<td><code>printSpeedCombined</code></td>
-<td>numeric</td>
-<td>pageperminute</td>
-</tr>
-<tr>
-<td><code>processorCache</code></td>
-<td>numeric</td>
-<td>kilobyte</td>
-</tr>
-<tr>
-<td><code>processorClockFrequency</code></td>
-<td>numeric</td>
-<td>hertz</td>
-</tr>
-<tr>
-<td><code>publisher</code></td>
-<td>string</td>
-<td>n/a</td>
-</tr>
-<tr>
-<td><code>ramSize</code></td>
-<td>numeric</td>
-<td>kilobyte</td>
-</tr>
-<tr>
-<td><code>refreshRate</code></td>
-<td>numeric</td>
-<td>hertz</td>
-</tr>
-<tr>
-<td><code>resolutionX</code></td>
-<td>numeric</td>
-<td>n/a</td>
-</tr>
-<tr>
-<td><code>resolutionY</code></td>
-<td>numeric</td>
-<td>n/a</td>
-</tr>
-<tr>
-<td><code>screenDiagonal</code></td>
-<td>numeric</td>
-<td>meter</td>
-</tr>
-<tr>
-<td><code>shippingDepth</code></td>
-<td>numeric</td>
-<td>meter</td>
-</tr>
-<tr>
-<td><code>shippingHeight</code></td>
-<td>numeric</td>
-<td>meter</td>
-</tr>
-<tr>
-<td><code>shippingLength</code></td>
-<td>numeric</td>
-<td>meter</td>
-</tr>
-<tr>
-<td><code>shippingWeight</code></td>
-<td>numeric</td>
-<td>kilogram</td>
-</tr>
-<tr>
-<td><code>shippingWidth</code></td>
-<td>numeric</td>
-<td>meter</td>
-</tr>
-<tr>
-<td><code>shoulders</code></td>
-<td>numeric</td>
-<td>meter</td>
-</tr>
-<tr>
-<td><code>sku</code></td>
-<td>string</td>
-<td>n/a</td>
-</tr>
-<tr>
-<td><code>sleeveLength</code></td>
-<td>numeric</td>
-<td>meter</td>
-</tr>
-<tr>
-<td><code>style</code></td>
-<td>string</td>
-<td>n/a</td>
-</tr>
-<tr>
-<td><code>subtitlesLanguage</code></td>
-<td>string</td>
-<td>n/a</td>
-</tr>
-<tr>
-<td><code>supportedRamSize</code></td>
-<td>numeric</td>
-<td>kilobyte</td>
-</tr>
-<tr>
-<td><code>thermalDesignPower</code></td>
-<td>numeric</td>
-<td>watt</td>
-</tr>
-<tr>
-<td><code>waist</code></td>
-<td>numeric</td>
-<td>meter</td>
-</tr>
-<tr>
-<td><code>warrantyDuration</code></td>
-<td>numeric</td>
-<td>second</td>
-</tr>
-<tr>
-<td><code>waterResistance</code></td>
-<td>numeric</td>
-<td>meter</td>
-</tr>
-<tr>
-<td><code>weight</code></td>
-<td>numeric</td>
-<td>kilogram</td>
-</tr>
-<tr>
-<td><code>weightCapacity</code></td>
-<td>numeric</td>
-<td>kilogram</td>
-</tr>
-<tr>
-<td><code>wheelDiameter</code></td>
-<td>numeric</td>
-<td>meter</td>
-</tr>
-<tr>
-<td><code>width</code></td>
-<td>numeric</td>
-<td>meter</td>
-</tr>
-</table>
-
-</div>
-
-
-</div>
-
-
-</div>
-
-
-
-
-
-
-</div>
+| Normalized Key | Type | Normalized Value Unit |
+| :------------- | :--- | :-------------------- |
+| `armLength` | numeric | meter |
+| `audioJackDiameter` | numeric | meter |
+| `batteryCapacity` | numeric | coulomb |
+| `bookFormat` | string | n/a |
+| `brand` | string | n/a |
+| `busClockFrequency` | numeric | hertz |
+| `bust` | numeric | meter |
+| `dataCapacity` | numeric | kilobyte |
+| `chest` | numeric | meter |
+| `circumference` | numeric | meter |
+| `clockFrequency` | numeric | hertz |
+| `color` | string | rgb hex value |
+| `condition` | string | n/a |
+| `copyingSpeed` | numeric | pageperminute |
+| `cordLength` | numeric | meter |
+| `countryOfOrigin` | string | n/a |
+| `dataReadSpeed` | numeric | kilobytepersecond |
+| `dataTransmissionSpeed` | numeric | kilobytepersecond |
+| `dataWriteSpeed` | numeric | kilobytepersecond |
+| `depth` | numeric | meter |
+| `diameter` | numeric | meter |
+| `fileSize` | numeric | kilobyte |
+| `focalLength` | numeric | meter |
+| `fuelConsumptionCity` | numeric | literperkilometer |
+| `fuelConsumptionCombined` | numeric | literperkilometer |
+| `fuelConsumptionHighway` | numeric | literperkilometer |
+| `gender` | string | n/a |
+| `genre` | string | n/a |
+| `gpuFrequencyClock` | numeric | hertz |
+| `heel` | numeric | meter |
+| `height` | numeric | meter |
+| `hips` | numeric | meter |
+| `impedance` | numeric | OHM |
+| `inkColor` | string | n/a |
+| `innerDiameter` | numeric | meter |
+| `inputVoltage` | numeric | volt |
+| `inseam` | numeric | meter |
+| `language` | string | n/a |
+| `length` | numeric | meter |
+| `lensDiameter` | numeric | meter |
+| `lensWidth` | numeric | meter |
+| `material` | string | n/a |
+| `maxFocalLength` | numeric | meter |
+| `maxFrequencyResponse` | numeric | hertz |
+| `maxWeight` | numeric | kilogram |
+| `maxWeightCapacity` | numeric | kilogram |
+| `maxOperatingTemperature` | numeric | celsius |
+| `maxStorageTemperature` | numeric | celsius |
+| `memoryClockFrequency` | numeric | hertz |
+| `mileage` | numeric | meter |
+| `minFocalLength` | numeric | meter |
+| `minFrequencyResponse` | numeric | hertz |
+| `minWeight` | numeric | kilogram |
+| `minWeightCapacity` | numeric | kilogram |
+| `minOperatingTemperature` | numeric | celsius |
+| `minStorageTemperature` | numeric | celsius |
+| `mpn` | string | n/a |
+| `neck` | numeric | meter |
+| `operating_temperature` | numeric | celsius |
+| `opticalWaveLength` | numeric | meter |
+| `outerDiameter` | numeric | meter |
+| `outputVoltage` | numeric | volt |
+| `power` | numeric | watt |
+| `powerConsumption` | numeric | watt |
+| `powerConsumptionIdle` | numeric | watt |
+| `powerDeveloped` | numeric | watt |
+| `powerRMS` | numeric | watt |
+| `printSpeedBlack` | numeric | pageperminute |
+| `printSpeedColor` | numeric | pageperminute |
+| `printSpeedCombined` | numeric | pageperminute |
+| `processorCache` | numeric | kilobyte |
+| `processorClockFrequency` | numeric | hertz |
+| `publisher` | string | n/a |
+| `ramSize` | numeric | kilobyte |
+| `refreshRate` | numeric | hertz |
+| `resolutionX` | numeric | n/a |
+| `resolutionY` | numeric | n/a |
+| `screenDiagonal` | numeric | meter |
+| `shippingDepth` | numeric | meter |
+| `shippingHeight` | numeric | meter |
+| `shippingLength` | numeric | meter |
+| `shippingWeight` | numeric | kilogram |
+| `shippingWidth` | numeric | meter |
+| `shoulders` | numeric | meter |
+| `sku` | string | n/a |
+| `sleeveLength` | numeric | meter |
+| `style` | string | n/a |
+| `subtitlesLanguage` | string | n/a |
+| `supportedRamSize` | numeric | kilobyte |
+| `thermalDesignPower` | numeric | watt |
+| `waist` | numeric | meter |
+| `warrantyDuration` | numeric | second |
+| `waterResistance` | numeric | meter |
+| `weight` | numeric | kilogram |
+| `weightCapacity` | numeric | kilogram |
+| `wheelDiameter` | numeric | meter |
+| `width` | numeric | meter |

--- a/docs/api-product.md
+++ b/docs/api-product.md
@@ -5,304 +5,107 @@ sidebar_label: Product Extraction API
 todo: Modify links to old API docs
 ---
 
-<div id="docBody">
+The Product API automatically extracts complete data from any shopping or e-commerce product page. Retrieve full pricing information, product IDs (SKU, UPC, MPN), images, product specifications, brand and more.
 
-<p>The Product API automatically extracts complete data from any shopping or e-commerce product page. Retrieve full pricing information, product IDs (SKU, UPC, MPN), images, product specifications, brand and more.</p>
-              
-<h3 id="request">Request</h3>
-<p>To use the Product API, perform a HTTP GET request on the following endpoint:</p>
-  
+## Request
 
-```text
+To use the Product API, perform a HTTP GET request on the following endpoint:
+
+```plaintext
 https://api.diffbot.com/v3/product
 ```
 
+Provide the following arguments:
 
-<p>Provide the following arguments:</p>
+| Argument | Description |
+| :------- | :---------- |
+| `token` | Developer token |
+| `url` | Web page URL of the product to process (URL encoded) </td></tr><tr><td colspan="2">**Optional arguments**</td> |
+| `fields` | Used to specify optional fields to be returned by the Product API. See the [Fields](#the-fields-argument) section below. |
+| `discussion` | Pass `discussion=false` to disable automatic extraction of product reviews. See [below](#review-extraction). |
+| `timeout` | Sets a value in milliseconds to wait for the retrieval/fetch of content from the requested URL. The default timeout for the third-party response is 30 seconds (30000). |
+| `callback` | Use for jsonp requests. Needed for cross-domain ajax. |
 
-<!--{arguments}--><table class="controls table table-bordered" id="arguments" border="0" cellpadding="5">
-<thead><tr>
-<th>Argument</th>
-<th>Description</th>
-</tr></thead>
+### The fields argument
 
-<tr>
-<td class=""><code>token</code></td>
-<td class=" default"><div>Developer token</div></td>
-</tr>
-<tr>
-<td class=""><code>url</code></td>
-<td class=" default"><div>Web page URL of the product to process (URL encoded)</div></td>
-</tr>
+Use the `fields` argument to return optional fields in the JSON response. The default fields will always be returned. For nested arrays, use parentheses to retrieve specific fields, or `*` to return all sub-fields.
 
-<tr>
-<td colspan="2" class="header">Optional arguments</td>
-</tr>
-<tr>
-<td class=""><code>fields</code></td>
-<td class=" optional"><div>Used to specify optional fields to be returned by the Product API. See the <a href="#fields">Fields</a> section below.</div></td>
-</tr>
-<tr>
-<td class=""><code>discussion</code></td>
-<td class=" optional"><div>Pass <code>discussion=false</code> to disable automatic extraction of product reviews. See <a href="#discussion">below</a>.</div></td>
-</tr>
-<tr>
-<td class=""><code>timeout</code></td>
-<td class=" optional"><div>Sets a value in milliseconds to wait for the retrieval/fetch of content from the requested URL. The default timeout for the third-party response is 30 seconds (30000).</div></td>
-</tr>
-<tr>
-<td class=""><code>callback</code></td>
-<td class=" optional"><div>Use for jsonp requests. Needed for cross-domain ajax.</div></td>
-</tr>
-</table>
-<!--{endarguments}-->
+For example, to return `links` and `meta` (in addition to the default fields), your `&fields` argument would be:</p>
 
-<h4 id="fields">The fields argument</h4>
-<p>Use the <code>fields</code> argument to return optional fields in the JSON response. The default fields will always be returned. For nested arrays, use parentheses to retrieve specific fields, or <code>*</code> to return all sub-fields.</p>
-<p>For example, to return <code>links</code> and <code>meta</code> (in addition to the default fields), your &amp;fields argument would be:</p>
-  
-
-```text
-&amp;fields=links,meta
+```plaintext
+&fields=links,meta
 ```
 
+## Response
 
-<h3 id="response">Response</h3>
-<p>The Product API returns data in JSON format.</p>
-<p>Each V3 response includes a <code>request</code> object (which returns request-specific metadata), and an <code>objects</code> array, which will include the extracted information for all objects on a submitted page.</p>
-<p>Objects in the Product API's <code>objects</code> array will include the following fields:</p>
+The Product API returns data in JSON format.
 
-<!--{fields}--><table class="controls table table-bordered" id="fields" border="0" cellpadding="5">
-<thead><tr>
-<th>Field</th>
-<th>Description</th>
-</tr></thead>
+Each V3 response includes a `request` object (which returns request-specific metadata), and an `objects` array, which will include the extracted information for all objects on a submitted page.
 
-<tr>
-<td class=""><code>type</code></td>
-<td class=" default"><div>Type of object (always <code>product</code>).</div></td>
-</tr>
-<tr>
-<td class=""><code>pageUrl</code></td>
-<td class=" default"><div>URL of submitted page / page from which the product is extracted.</div></td>
-</tr>
-<tr>
-<td class=""><code>resolvedPageUrl</code></td>
-<td class=" default"><div>Returned if the <code>pageUrl</code> redirects to another URL.</div></td>
-</tr>
-<tr>
-<td class=""><code>title</code></td>
-<td class=" default"><div>Title of the product.</div></td>
-</tr>
-<tr>
-<td class=""><code>text</code></td>
-<td class=" default"><div>Text description, if available, of the product.</div></td>
-</tr>
-<tr>
-<td class=""><code>brand</code></td>
-<td class=" default"><div>Item's brand name.</div></td>
-</tr>
-<tr>
-<td class=""><code>offerPrice</code></td>
-<td class=" default"><div>Offer or actual/final price of the product.</div></td>
-</tr>
-<tr>
-<td class=""><code>regularPrice</code></td>
-<td class=" default"><div>Regular or original price of the product, if available.</div></td>
-</tr>
-<tr>
-<td class=""><code>shippingAmount</code></td>
-<td class=" default"><div>Shipping price.</div></td>
-</tr>
-<tr>
-<td class=""><code>saveAmount</code></td>
-<td class=" default"><div>Discount or amount saved off the regular price.</div></td>
-</tr>
-<tr>
-<td class=""><code>offerPriceDetails</code></td>
-<td class=" default"><div>
-<code>offerPrice</code> separated into its constituent parts: <code>amount</code>, <code>symbol</code>, and full <code>text</code>.</div></td>
-</tr>
-<tr>
-<td class=""><code>regularPriceDetails</code></td>
-<td class=" default"><div>
-<code>regularPrice</code> separated into its constituent parts: <code>amount</code>, <code>symbol</code>, and full <code>text</code>.</div></td>
-</tr>
-<tr>
-<td class=""><code>saveAmountDetails</code></td>
-<td class=" default"><div>
-<code>saveAmount</code> separated into its constituent parts: <code>amount</code>, <code>symbol</code>, full <code>text</code>, and whether or not it is a <code>percentage</code> value.</div></td>
-</tr>
-<tr>
-<td class=""><code>productId</code></td>
-<td class=" default"><div>Diffbot-determined unique product ID. If <code>upc</code>, <code>isbn</code>, <code>mpn</code> or <code>sku</code> are identified on the page, <code>productId</code> will select from these values in the above order.</div></td>
-</tr>
-<tr>
-<td class=""><code>upc</code></td>
-<td class=" default"><div>Universal Product Code (UPC/EAN), if available.</div></td>
-</tr>
-<tr>
-<td class=""><code>sku</code></td>
-<td class=" default"><div>Stock Keeping Unit -- store/vendor inventory number or identifier.</div></td>
-</tr>
-<tr>
-<td class=""><code>mpn</code></td>
-<td class=" default"><div>Manufacturer's Product Number.</div></td>
-</tr>
-<tr>
-<td class=""><code>isbn</code></td>
-<td class=" default"><div>International Standard Book Number (ISBN), if available.</div></td>
-</tr>
-<tr>
-<td class=""><code>specs</code></td>
-<td class=" default"><div>If a specifications table or similar data is available on the product page, individual specifications will be returned in the <code>specs</code> object as name/value pairs. Names will be normalized to lowercase with spaces replaced by underscores, e.g. <code>display_resolution</code>.</div></td>
-</tr>
-<tr>
-<td class="parent"><code>images</code></td>
-<td class="parent default"><div>Array of images, if present within the product.</div></td>
-</tr>
-<tr>
-<td class="images indent"><code>url</code></td>
-<td class="images indent default"><div>Fully resolved link to image. If the image <code>SRC</code> is encoded as base64 data, the complete data URI will be returned.</div></td>
-</tr>
-<tr>
-<td class="images indent"><code>title</code></td>
-<td class="images indent default"><div>Description or caption of the image.</div></td>
-</tr>
-<tr>
-<td class="images indent"><code>height</code></td>
-<td class="images indent default"><div>Height of image as (re-)sized via browser/CSS.</div></td>
-</tr>
-<tr>
-<td class="images indent"><code>width</code></td>
-<td class="images indent default"><div>Width of image as (re-)sized via browser/CSS.</div></td>
-</tr>
-<tr>
-<td class="images indent"><code>naturalHeight</code></td>
-<td class="images indent default"><div>Raw image height, in pixels.</div></td>
-</tr>
-<tr>
-<td class="images indent"><code>naturalWidth</code></td>
-<td class="images indent default"><div>Raw image width, in pixels.</div></td>
-</tr>
-<tr>
-<td class="images indent"><code>primary</code></td>
-<td class="images indent default"><div>Returns <code>true</code> if image is identified as primary based on visual analysis.</div></td>
-</tr>
-<tr>
-<td class="images indent"><code>xpath</code></td>
-<td class="images indent default"><div>XPath expression identifying the image node.</div></td>
-</tr>
-<tr>
-<td class="images indent"><code>diffbotUri</code></td>
-<td class="images indent default"><div>Internal ID used for indexing.</div></td>
-</tr>
-<tr>
-<td class=""><code>discussion</code></td>
-<td class=" default"><div>Product reviews, as extracted by the Diffbot Discussion API. See <a href="#discussion">below</a>.</div></td>
-</tr>
-<tr>
-<td class=""><code>prefixCode</code></td>
-<td class=" default"><div>Country of origin as identified by UPC/ISBN.</div></td>
-</tr>
-<tr>
-<td class=""><code>productOrigin</code></td>
-<td class=" default"><div>If available, two-character ISO country code where the product was produced.</div></td>
-</tr>
-<tr>
-<td class=""><code>humanLanguage</code></td>
-<td class=" default"><div>Returns the (spoken/human) language of the submitted page, using two-letter <a href="http://en.wikipedia.org/wiki/List_of_ISO_639-1_codes" target="_blank">ISO 639-1 nomenclature</a>.</div></td>
-</tr>
-<tr>
-<td class=""><code>diffbotUri</code></td>
-<td class=" default"><div>Unique object ID. The <code>diffbotUri</code> is generated from the values of various Product fields and uniquely identifies the object. This can be used for deduplication.</div></td>
-</tr>
+Objects in the Product API's `objects` array will include the following fields:
 
-<tr>
-<td colspan="2" class="header">Optional fields, available using <code>fields=</code> argument</td>
-</tr>
-<tr>
-<td class=""><code>links</code></td>
-<td class=" optional"><div>Returns a top-level object (<code>links</code>) containing all hyperlinks found on the page.</div></td>
-</tr>
-<tr>
-<td class=""><code>meta</code></td>
-<td class=" optional"><div>Returns a top-level object (<code>meta</code>) containing the full contents of page <code>meta</code> tags, including sub-arrays for <a href="http://ogp.me/" target="_new">OpenGraph</a> tags, <a href="https://dev.twitter.com/docs/cards/markup-reference" target="_new">Twitter Card</a> metadata, <a href="http://www.schema.org" target="_new">schema.org</a> microdata, and -- if available -- <a href="http://www.oembed.com" target="_new">oEmbed</a> metadata.</div></td>
-</tr>
-<tr>
-<td class=""><code>querystring</code></td>
-<td class=" optional"><div>Returns any key/value pairs present in the URL querystring. Items without a discrete value will be returned as <code>true</code>.</div></td>
-</tr>
-<tr>
-<td class=""><code>breadcrumb</code></td>
-<td class=" optional"><div>Returns a top-level array (<code>breadcrumb</code>) of URLs and link text from page breadcrumbs.</div></td>
-</tr>
+| Field | Description |
+| :---- | :---------- |
+| `type` | Type of object (always `product`). |
+| `pageUrl` | URL of submitted page / page from which the product is extracted. |
+| `resolvedPageUrl` | Returned if the `pageUrl` redirects to another URL. |
+| `title` | Title of the product. |
+| `text` | Text description, if available, of the product. |
+| `brand` | Item's brand name. |
+| `offerPrice` | Offer or actual/final price of the product. |
+| `regularPrice` | Regular or original price of the product, if available. |
+| `shippingAmount` | Shipping price. |
+| `saveAmount` | Discount or amount saved off the regular price. |
+| `offerPriceDetails` | `offerPrice` separated into its constituent parts: `amount`, `symbol`, and full `text`. |
+| `regularPriceDetails` | `regularPrice` separated into its constituent parts: `amount`, `symbol`, and full `text`. |
+| `saveAmountDetails` | `saveAmount` separated into its constituent parts: `amount`, `symbol`, full `text`, and whether or not it is a `percentage` value. |
+| `productId` | Diffbot-determined unique product ID. If `upc`, `isbn`, `mpn` or `sku` are identified on the page, `productId` will select from these values in the above order. |
+| `upc` | Universal Product Code (UPC/EAN), if available. |
+| `sku` | Stock Keeping Unit -- store/vendor inventory number or identifier. |
+| `mpn` | Manufacturer's Product Number. |
+| `isbn` | International Standard Book Number (ISBN), if available. |
+| `specs` | If a specifications table or similar data is available on the product page, individual specifications will be returned in the `specs` object as name/value pairs. Names will be normalized to lowercase with spaces replaced by underscores, e.g. `display_resolution`. |
+| `images` | Array of images, if present within the product. |
+| &#x21B3;`url` |Fully resolved link to image. If the image `SRC` is encoded as base64 data, the complete data URI will be returned. |
+| &#x21B3;`title` | Description or caption of the image. |
+| &#x21B3;`height` | Height of image as (re-)sized via browser/CSS. |
+| &#x21B3;`width` | Width of image as (re-)sized via browser/CSS. |
+| &#x21B3;`naturalHeight` | Raw image height, in pixels. |
+| &#x21B3;`naturalWidth` | Raw image width, in pixels. |
+| &#x21B3;`primary` | Returns `true` if image is identified as primary based on visual analysis. |
+| &#x21B3;`xpath` | XPath expression identifying the image node. |
+| &#x21B3;`diffbotUri` | Internal ID used for indexing. |
+| `discussion` | Product reviews, as extracted by the Diffbot Discussion API. See [below](#review-extraction). |
+| `prefixCode` | Country of origin as identified by UPC/ISBN. |
+| `productOrigin` | If available, two-character ISO country code where the product was produced. |
+| `humanLanguage` | Returns the (spoken/human) language of the submitted page, using two-letter [ISO 639-1 nomenclature](https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes). |
+| `diffbotUri` | Unique object ID. The `diffbotUri` is generated from the values of various Product fields and uniquely identifies the object. This can be used for deduplication. </td></tr><tr><td colspan="2">**Optional fields, available using `fields=` argument**</td> |
+| `links` | Returns a top-level object (`links`) containing all hyperlinks found on the page. |
+| `meta` | Returns a top-level object (`meta`) containing the full contents of page `meta` tags, including sub-arrays for [OpenGraph](https://ogp.me/) tags, [Twitter Card](https://developer.twitter.com/en/docs/tweets/optimize-with-cards/overview/markup) metadata, [schema.org](https://www.schema.org) microdata, and -- if available -- [oEmbed](https://www.oembed.com) metadata. |
+| `querystring` | Returns any key/value pairs present in the URL querystring. Items without a discrete value will be returned as `true`. |
+| `breadcrumb` | Returns a top-level array (`breadcrumb`) of URLs and link text from page breadcrumbs. </td></tr><tr><td colspan="2">**The following fields are in an early beta stage:**</td> |
+| `availability` | Item's availability, either `true` or `false`. |
+| `category` | Returns an inferred category from Diffbot's [product categorization taxonomy](api-product-categories.md). |
+| `colors` | Returns array of product color options. |
+| `normalizedSpecs` | Returns normalized specifications if a specifications table (or similar element) is found on the product page. [More details on normalization](api-product-normalized-specs.md). |
+| `multipleProducts` | Returns `true` if multiple products are distinctly available on the product page. |
+| `priceRange` | If the product is available in a range of prices, the minimum and maximum values will be returned. The lowest price will also be returned as the `offerPrice`. |
+| &#x21B3;`minPrice` | The minimum price for the offered item. |
+| &#x21B3;`maxPrice` | The maximum price for the offered item. |
+| `quantityPrices` | If the product is available with quantity-based discounts, all identifiable price points will be returned. The lowest price will also be returned as the `offerPrice`. |
+| &#x21B3;`minQuantity` | The minimum quantity required to purchase for the associated price. |
+| &#x21B3;`price` | Price of the specific quantity level. |
+| `size` | Size(s) available, if identified on the page. |
 
-<tr>
-<td colspan="2" class="header">The following fields are in an early beta stage:</td>
-</tr>
-<tr>
-<td class=""><code>availability</code></td>
-<td class=" experimental"><div>Item's availability, either <code>true</code> or <code>false</code>.</div></td>
-</tr>
-<tr>
-<td class=""><code>category</code></td>
-<td class=" experimental"><div>Returns an inferred category from Diffbot's <a href="api-product-categories">product categorization taxonomy</a>.</div></td>
-</tr>
-<tr>
-<td class=""><code>colors</code></td>
-<td class=" experimental"><div>Returns array of product color options.</div></td>
-</tr>
-<tr>
-<td class=""><code>normalizedSpecs</code></td>
-<td class=" experimental"><div>Returns normalized specifications if a specifications table (or similar element) is found on the product page. <a href="api-product-normalized-specs">More details on normalization</a>.</div></td>
-</tr>
-<tr>
-<td class=""><code>multipleProducts</code></td>
-<td class=" experimental"><div>Returns <code>true</code> if multiple products are distinctly available on the product page.</div></td>
-</tr>
-<tr>
-<td class="parent"><code>priceRange</code></td>
-<td class="parent experimental"><div>If the product is available in a range of prices, the minimum and maximum values will be returned. The lowest price will also be returned as the <code>offerPrice</code>.</div></td>
-</tr>
-<tr>
-<td class="priceRange indent"><code>minPrice</code></td>
-<td class="priceRange indent experimental"><div>The minimum price for the offered item.</div></td>
-</tr>
-<tr>
-<td class="priceRange indent"><code>maxPrice</code></td>
-<td class="priceRange indent experimental"><div>The maximum price for the offered item.</div></td>
-</tr>
-<tr>
-<td class="parent"><code>quantityPrices</code></td>
-<td class="parent experimental"><div>If the product is available with quantity-based discounts, all identifiable price points will be returned. The lowest price will also be returned as the <code>offerPrice</code>.</div></td>
-</tr>
-<tr>
-<td class="quantityPrices indent"><code>minQuantity</code></td>
-<td class="quantityPrices indent experimental"><div>The minimum quantity required to purchase for the associated price.</div></td>
-</tr>
-<tr>
-<td class="quantityPrices indent"><code>price</code></td>
-<td class="quantityPrices indent experimental"><div>Price of the specific quantity level.</div></td>
-</tr>
+## Review Extraction
 
-<tr>
-<td class=""><code>size</code></td>
-<td class=" experimental"><div>Size(s) available, if identified on the page.</div></td>
-</tr>
-</table>
-<!--{endfields}-->
+By default the Product API will attempt to extract user reviews from product pages, using integrated functionality from the Diffbot Discussion API. Review data will be returned in the `discussion` object (nested within the primary product object). The full syntax for discussion data is available in the [Discussion API documentation](api-discussion.md).
 
-<h3 id="discussion">Review Extraction</h3>
-<p>By default the Product API will attempt to extract user reviews from product pages, using integrated functionality from the Diffbot Discussion API. Review data will be returned in the <code>discussion</code> object (nested within the primary product object). The full syntax for discussion data is available in the <a href="api-discussion">Discussion API documentation</a>.</p>
-<p>Discussion extraction can be disabled using the argument <code>discussion=false</code>. Note that if a page has recently been processed by Diffbot, cached reviews may be returned even if <code>discussion=false</code> is passed.</p>
+Discussion extraction can be disabled using the argument `discussion=false`. Note that if a page has recently been processed by Diffbot, cached reviews may be returned even if `discussion=false` is passed.
 
-<h3 id="sampleresponse">Example Response</h3>
-<div class="indent">
-  
+## Example Response
 
-```text
-
+```json
 {
   "request": {
     "pageUrl": "http://store.livrada.com/collections/all/products/before-i-go-to-sleep",
@@ -311,7 +114,6 @@ https://api.diffbot.com/v3/product
     "fields": "title,text,offerPrice,regularPrice,saveAmount,pageUrl,images",
     "version": 3
   },
-  {
   "objects": [
     {
       "type": "product",
@@ -328,57 +130,50 @@ https://api.diffbot.com/v3/product
           "xpath": "/HTML[@class='no-js']/BODY[@id='page-product']/DIV[@class='content-frame']/DIV[@class='content']/DIV[@class='content-shop']/DIV[@class='row']/DIV[@class='span5']/DIV[@class='product-thumbs']/UL/LI[@class='first-image']/A[@class='single_image']/IMG",
           "diffbotUri": "image|1|768070723"
         }
-      ]
+      ],
       "diffbotUri": "product|1|937176621"
     }
-  ],
+  ]
 }
 ```
 
 
-</div>
+## Authentication
 
-<h3 id="authenticating">Authentication</h3>
-<p>You can supply Diffbot with basic authentication credentials or custom HTTP headers (see below) to access intranet pages or other sites that require a login.</p>
+You can supply Diffbot with basic authentication credentials or custom HTTP headers (see below) to access intranet pages or other sites that require a login.
 
-<h4>Basic Authentication</h4>
-<p>To access pages that require a login/password (using <a href="http://en.wikipedia.org/wiki/Basic_access_authentication" target="_blank">basic access authentication</a>), include the username and password in your <code>url</code> parameter, e.g.: <code>url=http%3A%2F%2FUSERNAME:PASSWORD@www.diffbot.com</code>.</p>
+### Basic Authentication
 
-<h3 id="customheaders">Custom HTTP Headers</h3>
-<p>You can supply Diffbot APIs with custom HTTP headers that will be passed along when making requests to third-party sites. These can be used to define specific Referer, User-Agent, Cookie or any other values.</p>
-<p>Custom headers should be sent as HTTP headers in your request to <code>https://api.diffbot.com</code>, and prepended with <code>X-Forward-</code>.</p>
-<p>For instance, to send custom <code>User-Agent</code>, <code>Referer</code> and <code>My-Custom-Header</code> header values:</p>
-<table class="controls table table-bordered" border="0" cellpadding="5">
-<thead><tr>
-<th>Desired Header</th>
-<th>Send to api.diffbot.com</th>
-</tr></thead>
-<tbody>
-<tr>
-<td><code>User-Agent:Diffbot</code></td>
-<td><code>X-Forward-User-Agent:Diffbot</code></td>
-</tr>
-<tr>
-<td><code>Referer:diffbot.com</code></td>
-<td><code>X-Forward-Referer:diffbot.com</code></td>
-</tr>
-<tr>
-<td><code>My-Custom-Header:CustomValue</code></td>
-<td><code>X-Forward-My-Custom-Header:CustomValue</code></td>
-</tr>
-</tbody>
-</table>
+To access pages that require a login/password (using [basic access authentication](https://en.wikipedia.org/wiki/Basic_access_authentication)), include the username and password in your `url` parameter, e.g.: `url=http%3A%2F%2FUSERNAME:PASSWORD@www.diffbot.com`.
 
-<h3 id="x-evaluate">Custom Javascript</h3>
+## Custom HTTP Headers
+
+You can supply Diffbot APIs with custom HTTP headers that will be passed along when making requests to third-party sites. These can be used to define specific Referer, User-Agent, Cookie or any other values.
+
+Custom headers should be sent as HTTP headers in your request to `https://api.diffbot.com`, and prepended with `X-Forward-`.
+
+For instance, to send custom `User-Agent`, `Referer` and `My-Custom-Header` header values:
+
+| Desired Header | Send to api.diffbot.com |
+| :-- | :-- |
+| `User-Agent:Diffbot` | `X-Forward-User-Agent:Diffbot` |
+| `Referer:diffbot.com` | `X-Forward-Referer:diffbot.com` |
+| `My-Custom-Header:CustomValue` | `X-Forward-My-Custom-Header:CustomValue` |
+
+## Custom Javascript
+
 <div class="alert">This functionality is currently in beta.</div>
-<p>Using the <code>X-Evaluate</code> custom header (sent as <code>X-Forward-X-Evaluate</code>), you can inject your own Javascript code into web pages. Custom Javascript will be executed once the DOM has loaded.</p>
-<p>Custom Javascript should be provided as a text string and contained in its own function. You must also include the special functions <code>start()</code> and <code>end()</code> to indicate the beginning and end of your custom script. Once <code>end()</code> fires, the updated document will be processed by your chosen extraction API.</p>
-<p>It's recommended that your <code>end()</code> function be offset using <code>setTimeout</code> (see <a href="http://www.w3schools.com/js/js_timing.asp" target="_blank">JavaScript Timing Events</a>) in order to accommodate your primary function processing. Additionally, if your custom Javascript requires access to Ajax-delivered content, it may be necessary to offset your entire function using <code>setTimeout</code> in order to delay the start of your processing.</p>
-<p>The following sample <code>X-Evaluate</code> header waits one-half second after the DOM has loaded, enacts a click on the <code>a.loadMore</code> element, then waits 800 milliseconds before signaling the <code>end()</code>:</p>
+
+Using the `X-Evaluate` custom header (sent as `X-Forward-X-Evaluate`), you can inject your own Javascript code into web pages. Custom Javascript will be executed once the DOM has loaded.
+
+Custom Javascript should be provided as a text string and contained in its own function. You must also include the special functions `start()` and `end()` to indicate the beginning and end of your custom script. Once `end()` fires, the updated document will be processed by your chosen extraction API.
+
+It's recommended that your `end()` function be offset using `setTimeout` (see [JavaScript Timing Events](https://www.w3schools.com/js/js_timing.asp)) in order to accommodate your primary function processing. Additionally, if your custom Javascript requires access to Ajax-delivered content, it may be necessary to offset your entire function using `setTimeout` in order to delay the start of your processing.
+
+The following sample `X-Evaluate` header waits one-half second after the DOM has loaded, enacts a click on the `a.loadMore` element, then waits 800 milliseconds before signaling the `end()`:
 
 
-```text
-
+```js
 function() {
     start();
     setTimeout(function() {
@@ -393,41 +188,28 @@ function() {
         }
     }, 500);
 }
-
 ```
 
+Delivered as a string value as a custom header:
 
-
-<p>Delivered as a string value as a custom header:</p>
-
-
-```text
+```json
 "X-Forward-X-Evaluate": "function() {start();setTimeout(function(){var loadMoreNode=document.querySelector('a.loadMore');if (loadMoreNode != null) {loadMoreNode.click();setTimeout(function(){end();}, 800);} else {end();}},500);}"
 ```
 
+## Posting Content
 
+If your content is not publicly available (e.g., behind a firewall), you can POST markup directly to the Product API endpoint for analysis:
 
-<h3 id="posting">Posting Content</h3>
-<p>If your content is not publicly available (e.g., behind a firewall), you can POST markup directly to the Product API endpoint for analysis:
-</p>
-
-
-```text
-https://api.diffbot.com/v3/product?token=...&amp;url=...
+```plaintext
+https://api.diffbot.com/v3/product?token=...&url=...
 ```
 
+Please note that the `url` argument is still required, and will be used to resolve any relative links contained in the markup.
 
-<p>Please note that the <code>url</code> argument is still required, and will be used to resolve any relative links contained in the markup.</p>
-<p>Provide the content to analyze as your POST body, and specify the <code>Content-Type</code> header as <code>text/html</code>.</p>
-<p><strong>HTML Post Sample</strong>:</p>
-  
+Provide the content to analyze as your POST body, and specify the `Content-Type` header as `text/html`.
 
-```text
+### HTML Post Sample
 
-curl -H "Content-Type: text/html" -d '&lt;html&gt;&lt;head&gt;&lt;title&gt;Something to Buy&lt;/title&gt;&lt;/head&gt;&lt;body&gt;&lt;h2&gt;A Pair of Jeans&lt;/h2&gt;&lt;div&gt;Price: $31.99&lt;/div&gt;&lt;/body&gt;&lt;/html&gt;' 'https://api.diffbot.com/v3/product?token=...&amp;url=http%3A%2F%2Fstore.diffbot.com'
+```plaintext
+curl -H "Content-Type: text/html" -d '<html><head><title>Something to Buy</title></head><body><h2>A Pair of Jeans</h2><div>Price: $31.99</div></body></html>' 'https://api.diffbot.com/v3/product?token=...&url=http%3A%2F%2Fstore.diffbot.com'
 ```
-
-
-
-
-</div>

--- a/docs/api-search.md
+++ b/docs/api-search.md
@@ -5,193 +5,89 @@ sidebar_label: Search API
 todo: Modify links to old Dashboard
 ---
 
-<div id="docBody">
+Diffbot's Search API allows you to search the extracted content of your Diffbot "collections." A collection is a discrete <a href="/dev/crawl">Crawlbot</a> or <a href="/dev/bulk">Bulk API</a> job, and includes all of the web pages processed within that job.
 
-<p>Diffbot's Search API allows you to search the extracted content of your Diffbot "collections." A collection is a discrete <a href="/dev/crawl">Crawlbot</a> or <a href="/dev/bulk">Bulk API</a> job, and includes all of the web pages processed within that job.</p>
-<p>In order to search a collection, you must first create that collection using either Crawlbot or the Bulk API. A collection can be searched before a crawl or bulk job is finished.</p>
-<h3 id="request">Request</h3>
-<p>To use the Search API, perform a GET request on the following endpoint:</p>
-  
+In order to search a collection, you must first create that collection using either Crawlbot or the Bulk API. A collection can be searched before a crawl or bulk job is finished.
 
-```text
+## Request
+
+To use the Search API, perform a GET request on the following endpoint:
+
+```plaintext
 https://api.diffbot.com/v3/search
 ```
 
+Provide the following arguments:
 
-<p>Provide the following arguments:</p>
-<table class="controls table table-bordered" border="0" cellpadding="5">
-<thead><tr>
-<th>Argument</th>
-<th>Description</th>
-</tr></thead>
-<tbody>
-<tr>
-<td><code>token</code></td>
-<td>Developer <a href="https://diffbot.com/pricing">token</a>
-</td>
-</tr>
-<tr>
-<td><code>query</code></td>
-<td>Search query. Must be <a href="http://en.wikipedia.org/wiki/Percent-encoding" target="_blank">URL-encoded</a>. Please see <a href="#query">query operators</a> below.</td>
-</tr>
-<tr>
-<td><code>col</code></td>
-<td>Name of the collection (Crawlbot or Bulk job name) to search.</td>
-</tr>
-<tr><td colspan="2"><strong>Optional arguments</strong></td></tr>
-<tr>
-<td><code>num</code></td>
-<td>Number of results to return. Default is 20. To return all results in the search, pass <code>num=all</code>.</td>
-</tr>
-<tr>
-<td><code>start</code></td>
-<td>Ordinal position of first result to return. (First position is 0.) Default is 0.</td>
-</tr>
-</tbody>
-</table>
+| Argument | Description |
+| :------- | :---------- |
+| `token` | Developer [token](https://www.diffbot.com/pricing) |
+| `query` | Search query. Must be [URL-encoded](https://en.wikipedia.org/wiki/Percent-encoding). Please see [query operators](#query-operators) below. |
+| `col` | Name of the collection (Crawlbot or Bulk job name) to search. </td></tr><tr><td colspan="2">**Optional arguments**</td> |
+| `num` | Number of results to return. Default is 20. To return all results in the search, pass `num=all`. |
+| `start` | Ordinal position of first result to return. (First position is 0.) Default is 0. |
 
-<h3 id="query">Query Operators</h3>
-<p>The <code>query</code> argument contains the actual search contents you wish to perform on your collection(s). Multiple operators and values can be combined.</p>
+## Query Operators
 
-<table class="controls table vanilla" border="0" cellpadding="5">
-<thead><tr>
-<th>query=</th>
-<th>Returns...</th>
-</tr></thead>
-<tbody>
-<tr>
-<td>computer vision</td>
-<td>All objects containing "computer" and "vision" anywhere in all Diffbot-extracted fields.</td>
-</tr>
-<tr>
-<td>"web page analysis"</td>
-<td>All objects containing the phrase "web page analysis" anywhere in all Diffbot-extracted fields.</td>
-</tr>
-<tr>
-<td><span>author:<span style="color:#888">"John Henry"</span></span></td>
-<td>
-<span>All objects containing "John Henry" in the <code>author</code> field. All Diffbot fields within a collection can be queried against.</span><br><br>
-<strong>Other examples:</strong> tags:"Barack Obama", offerPrice:10.00</td>
-</tr>
-<tr>
-<td><span>images.caption:<span style="color:#888">flower</span></span></td>
-<td>
-<span>All objects containing "flower" in the <code>caption</code> field within a nested <code>images</code> array.</span><br><br>
-<strong>Other example:</strong> images.url:amazon.com</td>
-</tr>
-<tr>
-<td><span>type:<span style="color:#888">article</span></span></td>
-<td>
-<span>All objects identified as articles / processed by the Article API.</span><br><br><strong>Other examples:</strong> type:product, type:image</td>
-</tr>
-<tr>
-<td>
-<span style="color:#888">football</span> -49ers</td>
-<td>All objects containing "football" but not containing "49ers," in all Diffbot-extracted fields.<br><br><strong>Other examples:</strong> title:pantene -title:conditioner, text:diffbot -author:"farhad manjoo"</td>
-</tr>
-<tr>
-<td>
-<span style="color:#888">john</span> OR <span style="color:#888">paul</span>
-</td>
-<td>Objects containing either "john" or "paul" in Diffbot-extracted fields. <code>OR</code> must be capitalized.<br><br><strong>Other examples:</strong> title:ukraine OR title:putin, "bill clinton" OR "george bush", title:"puppy chow" OR text:"dog food"
-</td>
-</tr>
-<tr>
-<td>
-<span style="color:#888">george</span> AND <span style="color:#888">ringo</span>
-</td>
-<td>Objects containing both "george" and "ringo" in Diffbot-extracted fields. <code>AND</code> must be capitalized.<br><br><strong>Other examples:</strong> title:lakers AND text:basketball, "red sox" AND author:"bill simmons"</td>
-</tr>
-<!--<tr><td><span style="color:#888">"beach boys"</span> AND NOT <span style="color:#888">beatles</span></td><td>Objects containing "beach boys" but not containing "beatles" in any Diffbot-extracted fields. <code>AND NOT</code> must be capitalized.<br><br><strong>Other examples:</strong> title:pantene AND NOT title:conditioner, text:diffbot AND NOT author:"farhad manjoo"</td></tr>-->
-<tr>
-<td>(<span style="color:#888">obama</span> OR <span style="color:#888">clinton</span>) AND <span style="color:#888">president</span>
-</td>
-<td>Objects either "obama" or "clinton," and also "president." Parentheses can be used to nest Boolean queries.<br><br><strong>Other examples:</strong> (title:diffbot AND title:robots) OR title:startup</td>
-</tr>
-<tr>
-<td><span>site:<span style="color:#888">diffbot.com</span></span></td>
-<td><span>All objects extracted from diffbot.com. The site operator queries against values in the <code>pageUrl</code> and <code>resolvedPageUrl</code> fields.</span></td>
-</tr>
-<tr>
-<td><span>sortby:<span style="color:#888">timestamp</span></span></td>
-<td>Objects sorted (descending) by the specified Diffbot field. Must be a numeric (e.g. "offerPrice") or date field. For date formatting, see <a href="#date">Date Queries</a> below.</td>
-</tr>
-<tr>
-<td><span>revsortby:<span style="color:#888">date</span></span></td>
-<td>Objects sorted (ascending) by the specified Diffbot field. Must be a numeric or date field. For date formatting, see <a href="#date">Date Queries</a> below.</td>
-</tr>
-<tr>
-<td><span>min:<span style="color:#888">timestamp:1426784899</span></span></td>
-<td>All objects indexed (processed) after March 19, 2015 (in Unix epoch time). The <code>min</code> or <code>max</code> operators work only with numeric or date fields. For date formatting options, see <a href="#date">Date Queries</a> below.</td>
-</tr>
-<tr>
-<td><span>max:<span style="color:#888">offerPrice:1000</span></span></td>
-<td>All objects with an offerPrice value equal to or less than "1000." Must be a numeric or date field. For date formatting options, see <a href="#date">Date Queries</a> below.</td>
-</tr>
-</tbody>
-</table>
-<h4>Query URL Encoding</h4>
-<p>Be sure to <a href="http://en.wikipedia.org/wiki/Percent-encoding" target="_blank">URL-encode</a> your query. The following examples show some sample queries properly encoded.</p>
-<table class="controls table vanilla" border="0" cellpadding="5">
-<thead><tr>
-<th>Query</th>
-<th>URL-Encoded Query</th>
-</tr></thead>
-<tbody>
-<tr>
-<td>computer vision</td>
-<td>computer%20vision</td>
-</tr>
-<tr>
-<td>obama type:article sortby:date</td>
-<td>obama%20type%3Aarticle%20sortby%3Adate</td>
-</tr>
-<tr>
-<td>text:cats author:"Jet Li" min:date:1399669321</td>
-<td><div class="wordwrap">text%3Acats%20author%3A%22Jet%20Li%22%20min%3Adate%3A1399669321</div></td>
-</tr>
-<tr>
-<td>min:date:"Thu, 22 May 2014 00:00:00 GMT"</td>
-<td><div class="wordwrap">min%3Adate%3A%22Thu%2C%2022%20May%202014%2000%3A00%3A00%20GMT%22</div></td>
-</tr>
-</tbody>
-</table>
-<p>The space character can be represented by "%20" or the "+"-sign.</p>
-<h4 id="date">Date Queries</h4>
-<p>You can query against Diffbot API <code>date</code> fields (the extracted article or discussion post date, for instance), or against the <code>timestamp</code> field, which represents the time of an object's indexing into the collection.</p>
-<p>The <code>timestamp</code> field can be used to <a href="guides-download-latest-round-crawl-results">return the latest content</a> from a crawl or bulk job (e.g. <code>min:timestamp:2015-03-01</code>, for instance only the objects found in the last crawl round, or since the last search was run.</p>
-<p>When querying dates, your date values should be in one the following formats:</p>
-<ul>
-<li>
-<a href="http://en.wikipedia.org/wiki/ISO_8601" target="_blank">ISO 8601</a>, e.g. <code>2014-05-09</code> or <code>2014-05-10T17:40:25+00:00</code>
-</li>
-<li>
-<a href="http://en.wikipedia.org/wiki/Unix_time" target="_blank">Unix timestamp</a>, e.g. <code>1399669321</code>
-</li>
-<li>
-<a href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec3.html#sec3.3" target="_blank">RFC 1123 (HTTP/1.1) </a>, e.g. <code>"Fri, 09 May 2014 23:41:22 GMT"</code>
-</li>
-<!--<li>Any human-readable date-string in YMD order, which Diffbot will attempt to normalize, e.g. <code>20140501</code>.</li>-->
-</ul>
-<p>Be sure to wrap any space-containing date strings in quotation marks.</p>
-<p>
+The `query` argument contains the actual search contents you wish to perform on your collection(s). Multiple operators and values can be combined.
 
+| query= | Returns... |
+| :----- | :--------- |
+| computer vision | All objects containing "computer" and "vision" anywhere in all Diffbot-extracted fields. |
+| "web page analysis" | All objects containing the phrase "web page analysis" anywhere in all Diffbot-extracted fields. |
+| author:"John Henry" | All objects containing "John Henry" in the `author` field. All Diffbot fields within a collection can be queried against.<br><br>**Other examples:** tags:"Barack Obama", offerPrice:10.00 |
+| images.caption:flower | All objects containing "flower" in the `caption` field within a nested `images` array.<br><br>**Other example:** images.url:amazon.com |
+| type:article | All objects identified as articles / processed by the Article API.<br><br>**Other examples:** type:product, type:image |
+| football -49ers | All objects containing "football" but not containing "49ers," in all Diffbot-extracted fields.<br><br>**Other examples:** title:pantene -title:conditioner, text:diffbot -author:"farhad manjoo" |
+| john OR paul | Objects containing either "john" or "paul" in Diffbot-extracted fields. `OR` must be capitalized.<br><br>**Other examples:** title:ukraine OR title:putin, "bill clinton" OR "george bush", title:"puppy chow" OR text:"dog food" |
+| george AND ringo | Objects containing both "george" and "ringo" in Diffbot-extracted fields. `AND` must be capitalized.<br><br>**Other examples:** title:lakers AND text:basketball, "red sox" AND author:"bill simmons" |
+| (obama OR clinton) AND president | Objects containing either "obama" or "clinton," and also "president." Parentheses can be used to nest Boolean queries.<br><br>**Other examples:** (title:diffbot AND title:robots) OR title:startup |
+| site:diffbot.com | All objects extracted from diffbot.com. The site operator queries against values in the `pageUrl` and `resolvedPageUrl` fields. |
+| sortby:timestamp | Objects sorted (descending) by the specified Diffbot field. Must be a numeric (e.g. "offerPrice") or date field. For date formatting, see [Date Queries](#date-queries) below. |
+| revsortby:date | Objects sorted (ascending) by the specified Diffbot field. Must be a numeric or date field. For date formatting, see [Date Queries](#date-queries) below. |
+| min:timestamp:1426784899 | All objects indexed (processed) after March 19, 2015 (in Unix epoch time). The `min` or `max` operators work only with numeric or date fields. For date formatting options, see [Date Queries](#date-queries) below. |
+| max:offerPrice:1000 | All objects with an offerPrice value equal to or less than "1000." Must be a numeric or date field. For date formatting options, see [Date Queries](#date-queries) below. |
 
-</p>
-<hr>
-<h3 id="response">Response</h3>
-<p>The Search API returns all matching objects found in the collection(s) searched in a JSON format.</p>
-<p>Each response includes a <code>request</code> object (metadata specific to the search request), and an <code>objects</code> array, which will include the extracted information for all matching objects.</p>
-<p>The specific fields returned within each object depend upon the type of each object, and the fields requested in the Crawlbot or Bulk API jobs that populate your collection(s).</p>
+### Query URL Encoding
 
- 
+Be sure to [URL-encode](https://en.wikipedia.org/wiki/Percent-encoding) your query. The following examples show some sample queries properly encoded.
 
-```text
+| Query | URL-Encoded Query |
+| :---- | :---------------- |
+| computer vision | computer%20vision |
+| obama type:article sortby:date | obama%20type%3Aarticle%20sortby%3Adate |
+| text:cats author:"Jet Li" min:date:1399669321 | text%3Acats%20author%3A%22Jet%20Li%22%20min%3Adate%3A1399669321 |
+| min:date:"Thu, 22 May 2014 00:00:00 GMT" | min%3Adate%3A%22Thu%2C%2022%20May%202014%2000%3A00%3A00%20GMT%22 |
 
+The space character can be represented by "%20" or the "+"-sign.
+
+### Date Queries
+
+You can query against Diffbot API `date` fields (the extracted article or discussion post date, for instance), or against the `timestamp` field, which represents the time of an object's indexing into the collection.
+
+The `timestamp` field can be used to [return the latest content](guides-download-latest-round-crawl-results.md) from a crawl or bulk job (e.g. `min:timestamp:2015-03-01`, for instance only the objects found in the last crawl round, or since the last search was run.
+
+When querying dates, your date values should be in one the following formats:
+
+- [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601), e.g. `2014-05-09` or `2014-05-10T17:40:25+00:00`
+- [Unix timestamp](https://en.wikipedia.org/wiki/Unix_time), e.g. `1399669321`
+- [RFC 1123 (HTTP/1.1)](https://www.w3.org/Protocols/rfc2616/rfc2616-sec3.html#sec3.3), e.g. `"Fri, 09 May 2014 23:41:22 GMT"`
+
+Be sure to wrap any space-containing date strings in quotation marks.
+
+## Response
+
+The Search API returns all matching objects found in the collection(s) searched in a JSON format.
+
+Each response includes a `request` object (metadata specific to the search request), and an `objects` array, which will include the extracted information for all matching objects.
+
+The specific fields returned within each object depend upon the type of each object, and the fields requested in the Crawlbot or Bulk API jobs that populate your collection(s).
+
+```json
 {
   "request": {
     "num": 20,
-    "col": sampleCollection,
+    "col": "sampleCollection",
     "start": 0,
     "token": "...",
     "query": "diffy"
@@ -215,87 +111,49 @@ https://api.diffbot.com/v3/search
     "pageUrl": "http://blog.diffbot.com/diffbots-new-product-api-teaches-robots-to-shop-online/",
     "humanLanguage": "en",
     "text": "Diffbot's human wranglers are proud today to announce the release of our newest product: an API for... products!\nThe Product API can be used for extracting clean, structured data from any e-commerce product page. It automatically makes available all the product data you'd expect: price, discount/savings amount, shipping cost, product description, any relevant product images, SKU and/or other product IDs.\nEven cooler: pair the Product API with Crawlbot, our intelligent site-spidering tool, and let Diffbot determine which pages are products, then automatically structure the entire catalog. Here's a quick demonstration of Crawlbot at work:\nWe've developed the Product API over the course of two years, building upon our core vision technology that's extracted structured data from billions of web pages, and training our machine learning systems using data from tens of thousands of unique shopping sites. We can't wait for you to try it out.\nWhat are you waiting for? Check out the Product API documentation and dive on in! If you need a token, check out our pricing and plans (including our Free plan).\nQuestions? Hit us up at support@diffbot.com.",
-    "html": "&lt;p&gt;Diffbot’s human wranglers are proud today to announce the release of our newest product: an API for… products!&lt;/p&gt;&lt;p&gt;The &lt;a href=\"http://www.diffbot.com/products/automatic/product\"&gt;Product API&lt;/a&gt; can be used for extracting clean, structured data from any e-commerce product page. It automatically makes available all the product data you’d expect: price, discount/savings amount, shipping cost, product description, any relevant product images, SKU and/or other product IDs.&lt;/p&gt;&lt;p&gt;Even cooler: pair the Product API with &lt;a href=\"http://www.diffbot.com/products/crawlbot\"&gt;Crawlbot&lt;/a&gt;, our intelligent site-spidering tool, and let Diffbot determine which pages are products, then automatically structure the entire catalog. Here’s a quick demonstration of Crawlbot at work:&lt;/p&gt;&lt;figure&gt;&lt;iframe frameborder=\"0\" src=\"http://www.youtube.com/embed/lfcri5ungRo?feature=oembed\"&gt;&lt;/iframe&gt;&lt;/figure&gt;&lt;p&gt;We’ve developed the Product API over the course of two years, building upon our core vision technology that’s extracted structured data from billions of web pages, and training our machine learning systems using data from tens of thousands of unique shopping sites. We can’t wait for you to try it out.&lt;/p&gt;&lt;p&gt;What are you waiting for? Check out the &lt;a href=\"http://www.diffbot.com/products/automatic/product\"&gt;Product API documentation&lt;/a&gt; and dive on in! If you need a token, check out our &lt;a href=\"http://www.diffbot.com/pricing\"&gt;pricing and plans&lt;/a&gt; (including our Free plan).&lt;/p&gt;&lt;p&gt;Questions? Hit us up at &lt;a href=\"mailto:support@diffbot.com\"&gt;support@diffbot.com&lt;/a&gt;.&lt;/p&gt;",
+    "html": "<p>Diffbot’s human wranglers are proud today to announce the release of our newest product: an API for… products!</p><p>The <a href=\"http://www.diffbot.com/products/automatic/product\">Product API</a> can be used for extracting clean, structured data from any e-commerce product page. It automatically makes available all the product data you’d expect: price, discount/savings amount, shipping cost, product description, any relevant product images, SKU and/or other product IDs.</p><p>Even cooler: pair the Product API with <a href=\"http://www.diffbot.com/products/crawlbot\">Crawlbot</a>, our intelligent site-spidering tool, and let Diffbot determine which pages are products, then automatically structure the entire catalog. Here’s a quick demonstration of Crawlbot at work:</p><figure><iframe frameborder=\"0\" src=\"http://www.youtube.com/embed/lfcri5ungRo?feature=oembed\"></iframe></figure><p>We’ve developed the Product API over the course of two years, building upon our core vision technology that’s extracted structured data from billions of web pages, and training our machine learning systems using data from tens of thousands of unique shopping sites. We can’t wait for you to try it out.</p><p>What are you waiting for? Check out the <a href=\"http://www.diffbot.com/products/automatic/product\">Product API documentation</a> and dive on in! If you need a token, check out our <a href=\"http://www.diffbot.com/pricing\">pricing and plans</a> (including our Free plan).</p><p>Questions? Hit us up at <a href=\"mailto:support@diffbot.com\">support@diffbot.com</a>.</p>",
     "diffbotUri": "article|3|768070723"
     }
   ]
 }
-
 ```
 
+## Example Searches
 
+#### The most recently-written 40 articles in the "dailycrawl" collection.
 
+- query: `type:article sortby:date`
+- col: `dailycrawl`
+- num: `40`
 
-<hr>
-<h3 id="examples">Example Searches</h3>
-<div class="example">
-<p>The most recently-written 40 articles in the "dailycrawl" collection.</p>
-<ul>
-<li>query: <code>type:article sortby:date</code>
-</li>
-<li>col: <code>dailycrawl</code>
-</li>
-<li>num: <code>40</code>
-</li>
-</ul>
-  
-
-```text
-https://api.diffbot.com/v3/search?token=...&amp;num=40&amp;col=dailycrawl&amp;query=type%3Aarticle%20sortby%3Adate
+```plaintext
+https://api.diffbot.com/v3/search?token=...&num=40&col=dailycrawl&query=type%3Aarticle%20sortby%3Adate
 ```
 
+#### 100 articles written by Bill Simmons, at Grantland.com, from the "sports" collection, ordered by oldest first.
 
-</div>
-<div class="example">
-<p>100 articles written by Bill Simmons, at Grantland.com, from the "sports" collection, ordered by oldest first.</p>
-<ul>
-<li>query: <code>type:article author:"Bill Simmons" site:grandland.com revsortby:date</code>
-</li>
-<li>col: <code>sports</code>
-</li>
-<li>num: <code>100</code>
-</li>
-</ul>
-  
+- query: `type:article author:"Bill Simmons" site:grandland.com revsortby:date`
+- col: `sports`
+- num: `100`
 
-```text
-https://api.diffbot.com/v3/search?token=...&amp;num=100&amp;col=sports&amp;query=type%3Aarticle%20author%3A%22Bill%20Simmons%22%20site%3Agrandland.com%20revsortby%3Adate
+```plaintext
+https://api.diffbot.com/v3/search?token=...&num=100&col=sports&query=type%3Aarticle%20author%3A%22Bill%20Simmons%22%20site%3Agrandland.com%20revsortby%3Adate
 ```
 
+#### 20 articles mentioning "ukraine" or "Russia" in the main text, ordered by most recently indexed/crawled, from the "russiatoday" collections:
 
-</div>
-<div class="example">
-<p>20 articles mentioning "ukraine" or "Russia" in the main text, ordered by most recently indexed/crawled, from the "russiatoday" collections:</p>
-<ul>
-<li>query: <code>text:ukraine OR text:russia sortby:timestamp</code>
-</li>
-</ul>
-  
+- query: `text:ukraine OR text:russia sortby:timestamp`
 
-```text
-https://api.diffbot.com/v3/search?token=...&amp;col=russiatoday&amp;query=text%3Aukraine%20OR%20text%3Arussia%20sortby%3Atimestamp
+```plaintext
+https://api.diffbot.com/v3/search?token=...&col=russiatoday&query=text%3Aukraine%20OR%20text%3Arussia%20sortby%3Atimestamp
 ```
 
+#### The second page of 20 products with "Nike" in the title, between $40 and $50, from the "shoestores" collection:
 
-</div>
-<div class="example">
-<p>The second page of 20 products with "Nike" in the title, between $40 and $50, from the "shoestores" collection:</p>
-<ul>
-<li>query: <code>type:product title:nike min:offerPrice:40 max:offerPrice:50</code>
-</li>
-<li>col: <code>shoestores</code>
-</li>
-<li>start: <code>20</code>
-</li>
-</ul>
-  
+- query: `type:product title:nike min:offerPrice:40 max:offerPrice:50`
+- col: `shoestores`
+- start: `20`
 
-```text
-https://api.diffbot.com/v3/search?token=...&amp;col=shoestores&amp;start=20query=type%3Aproduct%20title%3Anike%20min%3AofferPrice%3A40%20max%3AofferPrice%3A50
+```plaintext
+https://api.diffbot.com/v3/search?token=...&col=shoestores&start=20query=type%3Aproduct%20title%3Anike%20min%3AofferPrice%3A40%20max%3AofferPrice%3A50
 ```
-
-
-</div>
-
-
-</div>

--- a/docs/api-selectors-filters.md
+++ b/docs/api-selectors-filters.md
@@ -4,308 +4,74 @@ title: Custom API Selectors and Filters
 sidebar_label: Custom API Selectors and Filters
 ---
 
-<div id="docBody">
-            
-<p>The API Toolkit uses advanced CSS selector logic to override the output of default Diffbot fields (in an Automatic API) or to create entirely new fields. When editing your rules, you can use the following selectors and logic to populate your output.</p>
-<h3 id="customheaders">Basic Selectors</h3>
+The API Toolkit uses advanced CSS selector logic to override the output of default Diffbot fields (in an Automatic API) or to create entirely new fields. When editing your rules, you can use the following selectors and logic to populate your output.
 
-<table class="table table-bordered" border="0" cellpadding="5">
-<tbody>
-<tr>
-<th align="left">Pattern</th>
-<th align="left">Matches</th>
-<th align="left">Example</th>
-</tr>
-<tr>
-<td><code>*</code></td>
-<td>any element</td>
-<td><code>*</code></td>
-</tr>
-<tr>
-<td><code>tagname</code></td>
-<td>elements with the given tag name</td>
-<td>
-<code>div</code>, <code>p</code>
-</td>
-</tr>
-<tr>
-<td><code>namespace|type</code></td>
-<td>elements of type 'type' in the namespace <i>ns</i>
-</td>
-<td>
-<code>fb|name</code> finds <code>&lt;fb:name&gt;</code> elements</td>
-</tr>
-<tr>
-<td><code>#id</code></td>
-<td>elements with attribute ID of "id"</td>
-<td>
-<code>div#container</code>, <code>#header</code>
-</td>
-</tr>
-<tr>
-<td><code>.class</code></td>
-<td>elements with a class name of "class"</td>
-<td>
-<code>div.left</code>, <code>.post-body</code>
-</td>
-</tr>
-<tr>
-<td>
-<code>element[attr]</code> or <code>[attr]</code>
-</td>
-<td>elements with an attribute named "attr" (with any value)</td>
-<td>
-<code>a[href]</code>, <code>[title]</code>
-</td>
-</tr>
-<tr>
-<td>
-<code>element[attr=val]</code> or <code>[attr=val]</code>
-</td>
-<td>elements with an attribute named "attr" and value equal to "val"</td>
-<td>
-<code>img[width=500]</code>, <code>a[rel=nofollow]</code>
-</td>
-</tr>
-<tr>
-<td><code>[^attrPrefix]</code></td>
-<td>elements with an attribute name starting with "attrPrefix". Use to find elements with HTML5 datasets</td>
-<td>
-<code>[^data-]</code>, <code>div[^data-]</code>
-</td>
-</tr>
-<tr>
-<td><code>[attr^=valPrefix]</code></td>
-<td>elements with an attribute named "attr", and value starting with "valPrefix"</td>
-<td><code>a[href^=http:]</code></td>
-</tr>
-<tr>
-<td><code>[attr$=valSuffix]</code></td>
-<td>elements with an attribute named "attr", and value ending with "valSuffix"</td>
-<td><code>img[src$=.png]</code></td>
-</tr>
-<tr>
-<td><code>[attr*=valContaining]</code></td>
-<td>elements with an attribute named "attr", and value containing "valContaining"</td>
-<td><code>a[href*=/search/]</code></td>
-</tr>
-<tr>
-<td><code>[attr~=<em>regex</em>]</code></td>
-<td>elements with an attribute named "attr", and value matching the regular expression</td>
-<td><code>img[src~=(?i)\\.(png|jpe?g)]</code></td>
-</tr>
-<tr>
-<td colspan="2"><em>The above may be combined in any order</em></td>
-<td><code>div.header[title]</code></td>
-</tr>
-</tbody>
-</table>
-<h3 id="combinators">Combinators</h3>
-<p>The following can be used to specify certain elements based on their relation to other elements on the page (parents, children, siblings, etc.).</p>
-<table class="table table-bordered" border="0" cellpadding="5">
-<tbody>
-<tr>
-<th align="left">Pattern</th>
-<th align="left">Matches</th>
-<th align="left">Example</th>
-</tr>
-<tr>
-<td><code>E F</code></td>
-<td>an F element descended from an E element</td>
-<td>
-<code>div a</code>, <code>.logo h1</code>
-</td>
-</tr>
-<tr>
-<td><code>E &gt; F</code></td>
-<td>an F direct child of E</td>
-<td><code>ol &gt; li</code></td>
-</tr>
-<tr>
-<td><code>E + F</code></td>
-<td>an F element immediately preceded by sibling E</td>
-<td>
-<code>li + li</code>, <code>div.head + div</code>
-</td>
-</tr>
-<tr>
-<td><code>E ~ F</code></td>
-<td>an F element preceded by sibling E</td>
-<td><code>h1 ~ p</code></td>
-</tr>
-<tr>
-<td><code>E, F, G</code></td>
-<td>all matching elements E, F, or G</td>
-<td><code>a[href], div, h3</code></td>
-</tr>
-</tbody>
-</table>
+## Basic Selectors
 
-<h3 id="pseudo">Pseudo Selectors</h3>
-<p>The following advanced selectors are also available.</p>
+| Pattern | Matches | Example |
+| :------ | :------ | :------ |
+| `*` | any element | `*` |
+| `tagname` | elements with the given tag name | `div`, `p` |
+| <code>namespace&#124;type</code> | elements of type 'type' in the namespace *ns* | <code>fb&#124;name</code> finds `<fb:name>` elements |
+| `#id` | elements with attribute ID of "id" | `div#container`, `#header` |
+| `.class` | elements with a class name of "class" | `div.left`, `.post-body` |
+| `element[attr]` or `[attr]` | elements with an attribute named "attr" (with any value) | `a[href]`, `[title]` |
+| `element[attr=val]` or `[attr=val]` | elements with an attribute named "attr" and value equal to "val" | `img[width=500]`, `a[rel=nofollow]` |
+| `[^attrPrefix]` | elements with an attribute name starting with "attrPrefix". Use to find elements with HTML5 datasets |`[^data-]`, `div[^data-]` |
+| `[attr^=valPrefix]` | elements with an attribute named "attr", and value starting with "valPrefix" | `a[href^=http:]` |
+| `[attr$=valSuffix]` | elements with an attribute named "attr", and value ending with "valSuffix" | `img[src$=.png]` |
+| `[attr*=valContaining]` | elements with an attribute named "attr", and value containing "valContaining" | `a[href*=/search/]` |
+| <code>[attr~=<em>regex</em>]</code> | elements with an attribute named "attr", and value matching the regular expression | <code>img[src~=(?i)\\.(png&#124;jpe?g)]</code> |
 
-<table class="table table-bordered" border="0" cellpadding="5">
-<tbody>
-<tr>
-<th align="left">Pattern</th>
-<th align="left">Matches</th>
-<th align="left">Example</th>
-</tr>
+The above may be combined in any order, such as `div.header[title]`
 
-<tr>
-<td><code>:first-child</code></td>
-<td>elements that are the first child of some other element</td>
-<td>
-<code>div &gt; p:first-child</code> finds the first child element of a <code>div</code> that happens to be a <code>p</code>
-</td>
-</tr>
-<tr>
-<td><code>:last-child</code></td>
-<td>elements that are the last child of some other element</td>
-<td>
-<code>ul &gt; li:last-child</code> finds the last list-item in each unordered list</td>
-</tr>
-<tr>
-<td><code>:only-child</code></td>
-<td>elements that are the only child of a parent element</td>
-<td>
-<code>p:only-child</code> finds paragraphs without sibling elements</td>
-</tr>
-<td><code>:first-of-type</code></td>
-<td>elements that are the first sibling <strong>of its type</strong> in the list of children of its parent element</td>
-<td>
-<code>div &gt; p:first-of-type</code> finds the first <code>p</code> element of each <code>div</code>
-</td>
-            
-<tr>
-<td><code>:last-of-type</code></td>
-<td>elements that are the last sibling <strong>of its type</strong> in the list of children of its parent element</td>
-<td>
-<code>div &gt; span:last-of-type</code> finds the last <code>span</code> element within <code>div</code> elements</td>
-</tr>
-<tr>
-<td><code>:only-of-type</code></td>
-<td>an element that has a parent element and whose parent element has no other element children <em>with the same expanded element name</em>
-</td>
-<td>
-<code>p:only-of-type</code> finds paragraphs without sibling <code>p</code> elements</td>
-</tr>
-<td><code>:empty</code></td>
-<td>elements that have no children at all</td>
-<td>
-<code>p:empty</code> finds paragraphs without children</td>
-            
-<tr>
-<td><code>:nth-child(<em>an+b</em>)</code></td>
-<td>elements that have <em>an+b-1</em> siblings <strong>before</strong> them in the document tree, for any positive integer or zero value of <em>n</em>, and have a parent element. Can also take 'odd' and 'even' as arguments. </td>
-<td>
-<code>tr:nth-child(2n+1)</code> finds every odd row of a table</td>
-</tr>
-<tr>
-<td><code>:nth-last-child(<em>an+b</em>)</code></td>
-<td>elements that have <em>an+b-1</em> siblings after <strong>after</strong> them in the document tree.</td>
-<td>
-<code>tr:nth-lastchild(-n+2)</code> finds the last two rows of a table</td>
-</tr>
-<tr>
-<td><code>:nth-of-type(<em>an+b</em>)</code></td>
-<td>represents an element that has <em>an+b-1</em> siblings with the same expanded element name <strong>before</strong> it in the document tree, for any zero or positive integer value of n, and has a parent element</td>
-<td><code>img:nth-of-type(2n+1)</code></td>
-</tr>
-<tr>
-<td><code>:nth-last-of-type(<em>an+b</em>)</code></td>
-<td>represents an element that has <em>an+b-1</em> siblings with the same expanded element name <strong>after</strong> it in the document tree, for any zero or positive integer value of n, and has a parent element</td>
-<td><code>img:nth-last-of-type(2n+1)</code></td>
-</tr>
-<tr>
-<td><code>:lt(<em>n</em>)</code></td>
-<td>elements whose sibling index is less than <em>n</em>
-</td>
-<td>
-<code>td:lt(3)</code> finds the first 2 cells of each row</td>
-</tr>
-<tr>
-<td><code>:gt(<em>n</em>)</code></td>
-<td>elements whose sibling index is greater than <em>n</em>
-</td>
-<td>
-<code>td:gt(1)</code> finds cells after skipping the first two</td>
-</tr>
-<tr>
-<td><code>:eq(<em>n</em>)</code></td>
-<td>elements whose sibling index is equal to <em>n</em>
-</td>
-<td>
-<code>td:eq(0)</code> finds the first cell of each row</td>
-</tr>
-<tr>
-<td><code>:has(<em>selector</em>)</code></td>
-<td>elements that contains at least one element matching the <em>selector</em>
-</td>
-<td>
-<code>div:has(p)</code> finds divs that contain p elements </td>
-</tr>
-<tr>
-<td><code>:not(<em>selector</em>)</code></td>
-<td>elements that do not match the <em>selector</em>
-</td>
-<td>
-<code>div:not(.logo)</code> finds all divs that do not have the "logo" class.<br><code>div:not(:has(div))</code> finds divs that do not contain divs.</td>
-</tr>
-<tr>
-<td><code>:contains(<em>text</em>)</code></td>
-<td>elements that contains the specified text. The search is case insensitive. The text may appear in the found element, or any of its descendants.</td>
-<td>
-<code>p:contains(jsoup)</code> finds p elements containing the text "jsoup".</td>
-</tr>
-<tr>
-<td><code>:matches(<em>regex</em>)</code></td>
-<td>elements whose text matches the specified regular expression. The text may appear in the found element, or any of its descendants.</td>
-<td>
-<code>td:matches(\\d+)</code> finds table cells containing digits. <code>div:matches((?i)login)</code> finds divs containing the text, case insensitively.</td>
-</tr>
-<tr>
-<td><code>:containsOwn(<em>text</em>)</code></td>
-<td>elements that directly contains the specified text. The search is case insensitive. The text must appear in the found element, not any of its descendants.</td>
-<td>
-<code>p:containsOwn(jsoup)</code> finds p elements with own text "jsoup".</td>
-</tr>
-<tr>
-<td><code>:matchesOwn(<em>regex</em>)</code></td>
-<td>elements whose own text matches the specified regular expression. The text must appear in the found element, not any of its descendants.</td>
-<td>
-<code>td:matchesOwn(\\d+)</code> finds table cells directly containing digits. <code>div:matchesOwn((?i)login)</code> finds divs containing the text, case insensitively.</td>
-</tr>
-<tr>
-<td colspan="2"><em>The above may be combined in any order and with other selectors.</em></td>
-<td><code>.light:contains(name):eq(0)</code></td>
-</tr>
-</tbody>
-</table>
+## Combinators
 
-<h3 id="filters">Output Filters</h3>
-<p>When creating a new rule, the following filters can be applied to the default selector output to further refine returned data.</p>
-<table class="table table-bordered" border="0" cellpadding="5">
-<tbody>
-<tr>
-<th align="left">Filter</th>
-<th align="left">Description</th>
-</tr>
-<tr>
-<td><strong>Attribute</strong></td>
-<td>Retrieves the specified attribute value of an element. For example, to extract the link (http://blog.diffbot.com) from the anchor tag <code>&lt;a href="http://www.blog.diffbot.com" class="outbound"&gt;</code>, you would enter <code>href</code> as your attribute filter. You can only use a single attribute filter per rule.</td>
-</tr>
-<tr>
-<td><strong>Ignore</strong></td>
-<td>Ignores the specified selectors (and all descendants) if they are found within the primary CSS selector. You may use any of the selector formats specified in this help screen.</td>
-</tr>
-<tr>
-<td><strong>Replace</strong></td>
-<td>Allows you to specify match and replace regular expressions to alter the output returned by the Diffbot API. To remove matching content, simply leave the "replace with" field blank.
-                  Backreferences are also supported.  For example, you can prepend text with the replace selector <code>(^.*$)</code> and replacement <code>prefix: $1</code><br><br>Diffbot uses a Java implementation for its regular expression parsing. <a href="http://www.regular-expressions.info/refcharacters.html" target="_blank">Regular-Expressions.info</a> offers an excellent overview of language-specific distinctions. For more details on Diffbot's regular expression implementation, please see <a href="guides-regex-custom-api" target="_blank">this Support article</a>.
-</td>
-</tr>
-</tbody>
-</table>
+The following can be used to specify certain elements based on their relation to other elements on the page (parents, children, siblings, etc.).
 
-</div>
+| Pattern | Matches | Example |
+| :------ | :------ | :------ |
+| `E F` | an F element descended from an E element | `div a`, `.logo h1` |
+| `E > F` | an F direct child of E | `ol > li` |
+| `E + F` | an F element immediately preceded by sibling E | `li + li`, `div.head + div` |
+| `E ~ F` | an F element preceded by sibling E | `h1 ~ p` |
+| `E, F, G` | all matching elements E, F, or G | `a[href], div, h3` |
+
+## Pseudo Selectors
+
+The following advanced selectors are also available.
+
+| Pattern | Matches | Example |
+| :------ | :------ | :------ |
+| `:first-child` | elements that are the first child of some other element | `div > p:first-child` finds the first child element of a `div` that happens to be a `p` |
+| `:last-child` | elements that are the last child of some other element | `ul > li:last-child` finds the last list-item in each unordered list |
+| `:only-child` | elements that are the only child of a parent element | `p:only-child` finds paragraphs without sibling elements
+| `:first-of-type` | elements that are the first sibling **of its type** in the list of children of its parent element | `div > p:first-of-type` finds the first `p` element of each `div` |
+| `:last-of-type` | elements that are the last sibling **of its type** in the list of children of its parent element | `div > span:last-of-type` finds the last `span` element within `div` elements |
+| `:only-of-type` | an element that has a parent element and whose parent element has no other element children *with the same expanded element name* | `p:only-of-type` finds paragraphs without sibling `p` elements
+| `:empty` | elements that have no children at all | `p:empty` finds paragraphs without children |
+| <code>:nth-child(<em>an+b</em>)</code> | elements that have *an+b-1* siblings **before** them in the document tree, for any positive integer or zero value of *n*, and have a parent element. Can also take 'odd' and 'even' as arguments. | `tr:nth-child(2n+1)` finds every odd row of a table |
+| <code>:nth-last-child(<em>an+b</em>)</code> | elements that have *an+b-1* siblings after **after** them in the document tree. | `tr:nth-lastchild(-n+2)` finds the last two rows of a table |
+| <code>:nth-of-type(<em>an+b</em>)</code> | represents an element that has *an+b-1* siblings with the same expanded element name **before** it in the document tree, for any zero or positive integer value of n, and has a parent element | `img:nth-of-type(2n+1)` |
+| <code>:nth-last-of-type(<em>an+b</em>)</code> | represents an element that has *an+b-1* siblings with the same expanded element name **after** it in the document tree, for any zero or positive integer value of n, and has a parent element | `img:nth-last-of-type(2n+1)` |
+| <code>:lt(<em>n</em>)</code> | elements whose sibling index is less than *n* | `td:lt(3)` finds the first 2 cells of each row |
+| <code>:gt(<em>n</em>)</code> | elements whose sibling index is greater than *n* | `td:gt(1)` finds cells after skipping the first two |
+| <code>:eq(<em>n</em>)</code> | elements whose sibling index is equal to *n* | `td:eq(0)` finds the first cell of each row |
+| <code>:has(<em>selector</em>)</code> | elements that contains at least one element matching the *selector* | `div:has(p)` finds divs that contain p elements |
+| <code>:not(<em>selector</em>)</code> | elements that do not match the *selector* | `div:not(.logo)` finds all divs that do not have the "logo" class.<br>`div:not(:has(div))` finds divs that do not contain divs. |
+| <code>:contains(<em>text</em>)</code> | elements that contains the specified text. The search is case insensitive. The text may appear in the found element, or any of its descendants. | `p:contains(jsoup)` finds p elements containing the text "jsoup". |
+| <code>:matches(<em>regex</em>)</code> | elements whose text matches the specified regular expression. The text may appear in the found element, or any of its descendants. | `td:matches(\\d+)` finds table cells containing digits. `div:matches((?i)login)` finds divs containing the text, case insensitively. |
+| <code>:containsOwn(<em>text</em>)</code> | elements that directly contains the specified text. The search is case insensitive. The text must appear in the found element, not any of its descendants. | `p:containsOwn(jsoup)` finds p elements with own text "jsoup". |
+| <code>:matchesOwn(<em>regex</em>)</code> | elements whose own text matches the specified regular expression. The text must appear in the found element, not any of its descendants. | `td:matchesOwn(\\d+)` finds table cells directly containing digits. `div:matchesOwn((?i)login)` finds divs containing the text, case insensitively. |
+
+The above may be combined in any order and with other selectors, such as `.light:contains(name):eq(0)`
+
+## Output Filters
+
+When creating a new rule, the following filters can be applied to the default selector output to further refine returned data.
+
+| Filter | Description |
+| :----- | :---------- |
+| **Attribute** | Retrieves the specified attribute value of an element. For example, to extract the link (http://blog.diffbot.com) from the anchor tag `<a href="http://www.blog.diffbot.com" class="outbound">`, you would enter `href` as your attribute filter. You can only use a single attribute filter per rule. |
+| **Ignore** | Ignores the specified selectors (and all descendants) if they are found within the primary CSS selector. You may use any of the selector formats specified in this help screen. |
+| **Replace** | Allows you to specify match and replace regular expressions to alter the output returned by the Diffbot API. To remove matching content, simply leave the "replace with" field blank. Backreferences are also supported. For example, you can prepend text with the replace selector `(^.*$)` and replacement `prefix: $1`<br><br>Diffbot uses a Java implementation for its regular expression parsing. [Regular-Expressions.info](https://www.regular-expressions.info/refcharacters.html) offers an excellent overview of language-specific distinctions. For more details on Diffbot's regular expression implementation, please see [this Support article](guides-regex-custom-api.md). |

--- a/docs/api-semantria.md
+++ b/docs/api-semantria.md
@@ -4,44 +4,23 @@ title: Semantria-Powered Text Analysis Features
 sidebar_label: Semantria-Powered Text Analysis Features
 ---
 
-<div id="docBody">
-<h3 id="request">Request</h3>
+## Request
 
-<div class="alert alert-warning">
-By default, Semantria accounts have a document-length limit of 2048 characters. In our integration, Diffbot will send up to 8192 characters of content to Semantria for analyis. Please contact your Semantria account manager to request an increase to 8192 characters in your Semantria account.</div>
-<p>To include Semantria-powered text analysis in your Article API response, include the following additional arguments:</p>
+<div class="alert">By default, Semantria accounts have a document-length limit of 2048 characters. In our integration, Diffbot will send up to 8192 characters of content to Semantria for analyis. Please contact your Semantria account manager to request an increase to 8192 characters in your Semantria account.</div>
 
-<!--{arguments}--><table class="controls table table-bordered" id="arguments" border="0" cellpadding="5">
-<thead><tr>
-<th>Argument</th>
-<th>Description</th>
-</tr></thead>
+To include Semantria-powered text analysis in your Article API response, include the following additional arguments:
 
-<tr>
-<td class=""><code>textAnalysis</code></td>
-<td class=" default"><div>Pass either <code>&amp;textAnalysis</code> or request the field <code>textAnalysis</code> to return the Semantria-powered object in your response.</div></td>
-</tr>
-<tr>
-<td class=""><code>semantriaKey</code></td>
-<td class=" default"><div>Include your Semantria API key (available from your Semantria dashboard).</div></td>
-</tr>
-<tr>
-<td class=""><code>semantriaSecret</code></td>
-<td class=" default"><div>Include your Semantria API secret (available from your Semantria dashboard).</div></td>
-</tr>
-</table>
-<!--{endarguments}-->
+| Argument | Description |
+| :------- | :---------- |
+| `textAnalysis` | Pass either `&textAnalysis` or request the field `textAnalysis` to return the Semantria-powered object in your response. |
+| `semantriaKey` | Include your Semantria API key (available from your Semantria dashboard). |
+| `semantriaSecret` | Include your Semantria API secret (available from your Semantria dashboard). |
 
+## Response
 
-<h3 id="response">Response</h3>
-<p>When using the above parameters, your Article API response will include a <code>textAnalysis</code> object, including the following Semantria objects: <code>autoCategories</code>, <code>entities</code>, <code>phrases</code>,  <code>themes</code>, <code>topics</code> and overall text <code>sentiment</code>. Sample response:
+When using the above parameters, your Article API response will include a `textAnalysis` object, including the following Semantria objects: `autoCategories`, `entities`, `phrases`,  `themes`, `topics` and overall text `sentiment`. Sample response:
 
-</p>
-<div class="indent">
-  
-
-```text
-
+```json
 "textAnalysis": {
    "sentiment":{
       "sentiment":"neutral",
@@ -285,8 +264,3 @@ By default, Semantria accounts have a document-length limit of 2048 characters. 
    ]
 }
 ```
-
-
-</div>
-
-</div>

--- a/docs/api-video.md
+++ b/docs/api-video.md
@@ -4,264 +4,147 @@ title: Video Extraction API
 sidebar_label: Video Extraction API
 ---
 
-<div id="docBody">
-
-
-<div class="tabbable">
-
-
-<div class="tab-content">
-<div class="tab-pane active" id="v3">
 <div class="alert">The Video API is currently in beta.</div>
 
-<p>The Video API automatically extracts detailed video information—including most metadata, thumbnail images, direct video URL and embed code—from nearly any video page or video platform on the web.</p>
-<h3 id="request">Request</h3>
-<p>To use the Video API, perform a HTTP GET request on the following endpoint:</p>
-  
+The Video API automatically extracts detailed video information—including most metadata, thumbnail images, direct video URL and embed code—from nearly any video page or video platform on the web.
 
-```text
+## Request
+
+To use the Video API, perform a HTTP GET request on the following endpoint:
+
+```plaintext
 https://api.diffbot.com/v3/video
 ```
 
+Provide the following arguments:
 
-<p>Provide the following arguments:</p>
+| Argument | Description |
+| :------- | :---------- |
+| `token` | Developer token |
+| `url` | Web page URL of the video to process (URL encoded) </td></tr><tr><td colspan="2">**Optional arguments**</td> |
+| `fields` | Used to specify optional fields to be returned by the Video API. See the [Fields](#the-fields-argument) section below. |
+| `timeout` | Sets a value in milliseconds to wait for the retrieval/fetch of content from the requested URL. The default timeout for the third-party response is 30 seconds (30000). |
+| `callback` | Use for jsonp requests. Needed for cross-domain ajax. |
 
-<!--{arguments}--><table class="controls table table-bordered" id="arguments" border="0" cellpadding="5">
-<thead><tr>
-<th>Argument</th>
-<th>Description</th>
-</tr></thead>
+### The fields argument
 
-<tr>
-<td class=""><code>token</code></td>
-<td class=" default"><div>Developer token</div></td>
-</tr>
-<tr>
-<td class=""><code>url</code></td>
-<td class=" default"><div>Web page URL of the video to process (URL encoded)</div></td>
-</tr>
+Use the `fields` argument to return optional fields in the JSON response. The default fields will always be returned. For nested arrays, use parentheses to retrieve specific fields, or `*` to return all sub-fields.
 
-<tr>
-<td colspan="2" class="header">Optional arguments</td>
-</tr>
-<tr>
-<td class=""><code>fields</code></td>
-<td class=" optional"><div>Used to specify optional fields to be returned by the Video API. See the <a href="#fields">Fields</a> section below.</div></td>
-</tr>
-<tr>
-<td class=""><code>timeout</code></td>
-<td class=" optional"><div>Sets a value in milliseconds to wait for the retrieval/fetch of content from the requested URL. The default timeout for the third-party response is 30 seconds (30000).</div></td>
-</tr>
-<tr>
-<td class=""><code>callback</code></td>
-<td class=" optional"><div>Use for jsonp requests. Needed for cross-domain ajax.</div></td>
-</tr>
-</table>
-<!--{endarguments}-->
+For example, to return `links` and `meta` (in addition to the default fields), your `&fields` argument would be:
 
-<!--  <h4 id="fields">The fields argument</h4>
-<p>Use the <code>fields</code> argument to return optional fields in the JSON response. The default fields will always be returned. For nested arrays, use parentheses to retrieve specific fields, or <code>*</code> to return all sub-fields.</p>
--->
-<h3 id="response">Response</h3>
-<p>Diffbot's V3 APIs return information about <strong>all</strong> identified objects on a submitted page.</p>
-<p>Each V3 response includes a <code>request</code> object (which returns request-specific metadata), and an <code>objects</code> array, which will include the extracted information for all objects on a submitted page.</p>
-<p>Objects in the Product API's <code>objects</code> array will include the following fields:</p>
+```plaintext
+&fields=links,meta
+```
 
-<!--{fields}--><table class="controls table table-bordered" id="fields" border="0" cellpadding="5">
-<thead><tr>
-<th>Field</th>
-<th>Description</th>
-</tr></thead>
+## Response
 
-<tr>
-<td class=""><code>type</code></td>
-<td class=" default"><div>Type of object (always <code>video</code>).</div></td>
-</tr>
-<tr>
-<td class=""><code>pageUrl</code></td>
-<td class=" default"><div>URL of submitted page / page from which the video is extracted.</div></td>
-</tr>
-<tr>
-<td class=""><code>resolvedPageUrl</code></td>
-<td class=" default"><div>Returned if the <code>pageUrl</code> redirects to another URL.</div></td>
-</tr>
-<tr>
-<td class=""><code>title</code></td>
-<td class=" default"><div>Title of the video.</div></td>
-</tr>
-<tr>
-<td class=""><code>text</code></td>
-<td class=" default"><div>Text description, if available, of the video.</div></td>
-</tr>
-<tr>
-<td class=""><code>url</code></td>
-<td class=" default"><div>Direct link to source video file, if available.</div></td>
-</tr>
-<tr>
-<td class=""><code>html</code></td>
-<td class=" default"><div>Embeddable HTML of the video (if available), typically an <code>IFRAME</code> or <code>VIDEO</code> object.</div></td>
-</tr>
-<tr>
-<td class=""><code>embedUrl</code></td>
-<td class=" default"><div>Embeddable URL, if available.</div></td>
-</tr>
-<tr>
-<td class=""><code>author</code></td>
-<td class=" default"><div>Video uploader or creator, if available.</div></td>
-</tr>
-<tr>
-<td class=""><code>date</code></td>
-<td class=" default"><div>Date of extracted video, normalized in most cases to <a href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec3.html#sec3.3">RFC 1123 (HTTP/1.1)</a>.</div></td>
-</tr>
-<tr>
-<td class=""><code>duration</code></td>
-<td class=" default"><div>Duration in seconds of the Video.</div></td>
-</tr>
-<tr>
-<td class=""><code>viewCount</code></td>
-<td class=" default"><div>Number of Video views, if available on the page.</div></td>
-</tr>
-<tr>
-<td class=""><code>naturalHeight</code></td>
-<td class=" default"><div>Raw video height, if available, in pixels.</div></td>
-</tr>
-<tr>
-<td class=""><code>naturalWidth</code></td>
-<td class=" default"><div>Raw video width, if available, in pixels.</div></td>
-</tr>
-<tr>
-<td class="parent"><code>images</code></td>
-<td class="parent default"><div>Array of images, if present within the video.</div></td>
-</tr>
-<tr>
-<td class="images indent"><code>url</code></td>
-<td class="images indent default"><div>Fully resolved link to image. If the image <code>SRC</code> is encoded as base64 data, the complete data URI will be returned.</div></td>
-</tr>
-<tr>
-<td class="images indent"><code>title</code></td>
-<td class="images indent default"><div>Description or caption of the image.</div></td>
-</tr>
-<tr>
-<td class=""><code>mime</code></td>
-<td class=" default"><div>MIME type, if available, as specified by the Video's "Content-Type."</div></td>
-</tr>
-<tr>
-<td class=""><code>humanLanguage</code></td>
-<td class=" default"><div>Returns the (spoken/human) language of the submitted page, using two-letter <a href="http://en.wikipedia.org/wiki/List_of_ISO_639-1_codes" target="_blank">ISO 639-1 nomenclature</a>.</div></td>
-</tr>
-<tr>
-<td class=""><code>diffbotUri</code></td>
-<td class=" default"><div>Unique object ID. The <code>diffbotUri</code> is generated from the values of various Video fields and uniquely identifies the object. This can be used for deduplication.</div></td>
-</tr>
+Diffbot's V3 APIs return information about **all** identified objects on a submitted page.
 
-<tr>
-<td colspan="2" class="header">Optional fields, available using <code>fields=</code> argument</td>
-</tr>
-<tr>
-<td class=""><code>links</code></td>
-<td class=" optional"><div>Returns a top-level object (<code>links</code>) containing all hyperlinks found on the page.</div></td>
-</tr>
-<tr>
-<td class=""><code>meta</code></td>
-<td class=" optional"><div>Returns a top-level object (<code>meta</code>) containing the full contents of page <code>meta</code> tags, including sub-arrays for <a href="http://ogp.me/" target="_new">OpenGraph</a> tags, <a href="https://dev.twitter.com/docs/cards/markup-reference" target="_new">Twitter Card</a> metadata, <a href="http://www.schema.org" target="_new">schema.org</a> microdata, and -- if available -- <a href="http://www.oembed.com" target="_new">oEmbed</a> metadata.</div></td>
-</tr>
-<tr>
-<td class=""><code>querystring</code></td>
-<td class=" optional"><div>Returns any key/value pairs present in the URL querystring. Items without a discrete value will be returned as <code>true</code>.</div></td>
-</tr>
-<tr>
-<td class=""><code>breadcrumb</code></td>
-<td class=" optional"><div>Returns a top-level array (<code>breadcrumb</code>) of URLs and link text from page breadcrumbs.</div></td>
-</tr>
-</table>
-<!--{endfields}-->
+Each V3 response includes a `request` object (which returns request-specific metadata), and an `objects` array, which will include the extracted information for all objects on a submitted page.
 
-<h3 id="sampleresponse">Example Response</h3>
-<div class="indent">
-  
+Objects in the Product API's `objects` array will include the following fields:
 
-```text
+| Field | Description |
+| :---- | :---------- |
+| `type` | Type of object (always `video`). |
+| `pageUrl` | URL of submitted page / page from which the video is extracted. |
+| `resolvedPageUrl` | Returned if the `pageUrl` redirects to another URL. |
+| `title` | Title of the video. |
+| `text` | Text description, if available, of the video. |
+| `url` | Direct link to source video file, if available. |
+| `html` | Embeddable HTML of the video (if available), typically an `IFRAME` or `VIDEO` object. |
+| `embedUrl` | Embeddable URL, if available. |
+| `author` | Video uploader or creator, if available. |
+| `date` | Date of extracted video, normalized in most cases to [RFC 1123 (HTTP/1.1)](https://www.w3.org/Protocols/rfc2616/rfc2616-sec3.html#sec3.3). |
+| `duration` | Duration in seconds of the Video. |
+| `viewCount` | Number of Video views, if available on the page. |
+| `naturalHeight` | Raw video height, if available, in pixels. |
+| `naturalWidth` | Raw video width, if available, in pixels. |
+| `images` | Array of images, if present within the video. |
+| &#x21B3;`url` |Fully resolved link to image. If the image `SRC` is encoded as base64 data, the complete data URI will be returned. |
+| &#x21B3;`title` | Description or caption of the image. |
+| `mime` | MIME type, if available, as specified by the Video's "Content-Type." |
+| `humanLanguage` | Returns the (spoken/human) language of the submitted page, using two-letter [ISO 639-1 nomenclature](https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes). |
+| `diffbotUri` | Unique object ID. The `diffbotUri` is generated from the values of various Video fields and uniquely identifies the object. This can be used for deduplication. </td></tr><tr><td colspan="2">**Optional fields, available using `fields=` argument**</td> |
+| `links` | Returns a top-level object (`links`) containing all hyperlinks found on the page. |
+| `meta` | Returns a top-level object (`meta`) containing the full contents of page `meta` tags, including sub-arrays for [OpenGraph](https://ogp.me/) tags, [Twitter Card](https://developer.twitter.com/en/docs/tweets/optimize-with-cards/overview/markup) metadata, [schema.org](https://www.schema.org) microdata, and -- if available -- [oEmbed](https://www.oembed.com) metadata. |
+| `querystring` | Returns any key/value pairs present in the URL querystring. Items without a discrete value will be returned as `true`. |
+| `breadcrumb` | Returns a top-level array (`breadcrumb`) of URLs and link text from page breadcrumbs. |
 
+## Example Response
+
+```json
 {
   "request": {
     "pageUrl": "https://www.youtube.com/watch?v=VNv3EZEUgok",
     "api": "video",
     "version": 3
   },
-  {
   "objects": [
     {
       "type": "video",
       "title": "Create a Custom API Using Diffbot's Custom API Toolkit",
       "text": "This demonstration shows how to create a completely custom API using Diffbot's Custom API Toolkit. In it we show how to extract the \"What's Hot\" / Trending links from http://www.mashable.com.",
       "pageUrl": "https://www.youtube.com/watch?v=VNv3EZEUgok",
-      "embedUrl": "http://www.youtube.com/v/VNv3EZEUgok?autohide=1&amp;version=3",
+      "embedUrl": "http://www.youtube.com/v/VNv3EZEUgok?autohide=1&version=3",
       "humanLanguage": "en",
       "date": "Fri, 02 Aug 2013 07:00:00 GMT",
-      "url": "https://r5---sn-qxo7sn7r.googlevideo.com/videoplayback?signature=3F99256DF92E9095B47FAC373A4BAADC5DBF3D36.D840BFEA083EE15085D0FE1F2F4C724551E7A4D7&amp;sver=3&amp;fexp=911305%2C912108%2C916944%2C930666%2C932404%2C940000%2C947209%2C947215%2C948124%2C948900%2C952302%2C952901%2C953912%2C957103%2C957201%2C958603&amp;ratebypass=yes&amp;requiressl=yes&amp;ipbits=0&amp;sparams=id%2Cip%2Cipbits%2Citag%2Cmm%2Cms%2Cmv%2Cratebypass%2Crequiressl%2Csource%2Cupn%2Cexpire&amp;key=yt5&amp;ip=146.148.32.139&amp;itag=22&amp;source=youtube&amp;mv=u&amp;ms=au&amp;mm=31&amp;mt=1415157849&amp;id=o-AJ5iG1T6_yn-_qUHjcNok6XqTznNX6LXeagB6-mm8XQM&amp;expire=1415179514&amp;upn=wMziid6h3DY",
+      "url": "https://r5---sn-qxo7sn7r.googlevideo.com/videoplayback?signature=3F99256DF92E9095B47FAC373A4BAADC5DBF3D36.D840BFEA083EE15085D0FE1F2F4C724551E7A4D7&sver=3&fexp=911305%2C912108%2C916944%2C930666%2C932404%2C940000%2C947209%2C947215%2C948124%2C948900%2C952302%2C952901%2C953912%2C957103%2C957201%2C958603&ratebypass=yes&requiressl=yes&ipbits=0&sparams=id%2Cip%2Cipbits%2Citag%2Cmm%2Cms%2Cmv%2Cratebypass%2Crequiressl%2Csource%2Cupn%2Cexpire&key=yt5&ip=146.148.32.139&itag=22&source=youtube&mv=u&ms=au&mm=31&mt=1415157849&id=o-AJ5iG1T6_yn-_qUHjcNok6XqTznNX6LXeagB6-mm8XQM&expire=1415179514&upn=wMziid6h3DY",
       "author": "Diffbot",
-      "html": "&lt;iframe width=\"459\" height=\"344\" src=\"http://www.youtube.com/embed/VNv3EZEUgok?feature=oembed\" frameborder=\"0\" allowfullscreen&gt;&lt;/iframe&gt;",
+      "html": "<iframe width=\"459\" height=\"344\" src=\"http://www.youtube.com/embed/VNv3EZEUgok?feature=oembed\" frameborder=\"0\" allowfullscreen></iframe>",
       "mime": "video/mp4",
       "duration": 343,
       "naturalWidth": 1280,
       "naturalHeight": 720,
-      "viewCount": 1000
+      "viewCount": 1000,
       "images": [
         {
           "title": "Create a Custom API Using Diffbot's Custom API Toolkit",
           "url": "http://i.ytimg.com/vi/VNv3EZEUgok/hqdefault.jpg",
         }
-      ]
-      "diffbotUri": "video|3|566075164",
+      ],
+      "diffbotUri": "video|3|566075164"
     }
-  ],
+  ]
 }
 ```
 
+## Authentication
 
-</div>
+You can supply Diffbot with basic authentication credentials or custom HTTP headers (see below) to access intranet pages or other sites that require a login.
 
-<h3 id="authenticating">Authentication</h3>
-<p>You can supply Diffbot with basic authentication credentials or custom HTTP headers (see below) to access intranet pages or other sites that require a login.</p>
+### Basic Authentication
 
-<h4>Basic Authentication</h4>
-<p>To access pages that require a login/password (using <a href="http://en.wikipedia.org/wiki/Basic_access_authentication" target="_blank">basic access authentication</a>), include the username and password in your <code>url</code> parameter, e.g.: <code>url=http%3A%2F%2FUSERNAME:PASSWORD@www.diffbot.com</code>.</p>
+To access pages that require a login/password (using [basic access authentication](https://en.wikipedia.org/wiki/Basic_access_authentication)), include the username and password in your `url` parameter, e.g.: `url=http%3A%2F%2FUSERNAME:PASSWORD@www.diffbot.com`.
 
-<h3 id="customheaders">Custom HTTP Headers</h3>
-<p>You can supply Diffbot APIs with custom HTTP headers that will be passed along when making requests to third-party sites. These can be used to define specific Referer, User-Agent, Cookie or any other values.</p>
-<p>Custom headers should be sent as HTTP headers in your request to <code>https://api.diffbot.com</code>, and prepended with <code>X-Forward-</code>.</p>
-<p>For instance, to send custom <code>User-Agent</code>, <code>Referer</code> and <code>My-Custom-Header</code> header values:</p>
-<table class="controls table table-bordered" border="0" cellpadding="5">
-<thead><tr>
-<th>Desired Header</th>
-<th>Send to api.diffbot.com</th>
-</tr></thead>
-<tbody>
-<tr>
-<td><code>User-Agent:Diffbot</code></td>
-<td><code>X-Forward-User-Agent:Diffbot</code></td>
-</tr>
-<tr>
-<td><code>Referer:diffbot.com</code></td>
-<td><code>X-Forward-Referer:diffbot.com</code></td>
-</tr>
-<tr>
-<td><code>My-Custom-Header:CustomValue</code></td>
-<td><code>X-Forward-My-Custom-Header:CustomValue</code></td>
-</tr>
-</tbody>
-</table>
+## Custom HTTP Headers
 
-<h3 id="x-evaluate">Custom Javascript</h3>
+You can supply Diffbot APIs with custom HTTP headers that will be passed along when making requests to third-party sites. These can be used to define specific Referer, User-Agent, Cookie or any other values.
+
+Custom headers should be sent as HTTP headers in your request to `https://api.diffbot.com`, and prepended with `X-Forward-`.
+
+For instance, to send custom `User-Agent`, `Referer` and `My-Custom-Header` header values:
+
+| Desired Header | Send to api.diffbot.com |
+| :-- | :-- |
+| `User-Agent:Diffbot` | `X-Forward-User-Agent:Diffbot` |
+| `Referer:diffbot.com` | `X-Forward-Referer:diffbot.com` |
+| `My-Custom-Header:CustomValue` | `X-Forward-My-Custom-Header:CustomValue` |
+
+## Custom Javascript
+
 <div class="alert">This functionality is currently in beta.</div>
-<p>Using the <code>X-Evaluate</code> custom header (sent as <code>X-Forward-X-Evaluate</code>), you can inject your own Javascript code into web pages. Custom Javascript will be executed once the DOM has loaded.</p>
-<p>Custom Javascript should be provided as a text string and contained in its own function. You must also include the special functions <code>start()</code> and <code>end()</code> to indicate the beginning and end of your custom script. Once <code>end()</code> fires, the updated document will be processed by your chosen extraction API.</p>
-<p>It's recommended that your <code>end()</code> function be offset using <code>setTimeout</code> (see <a href="http://www.w3schools.com/js/js_timing.asp" target="_blank">JavaScript Timing Events</a>) in order to accommodate your primary function processing. Additionally, if your custom Javascript requires access to Ajax-delivered content, it may be necessary to offset your entire function using <code>setTimeout</code> in order to delay the start of your processing.</p>
-<p>The following sample <code>X-Evaluate</code> header waits one-half second after the DOM has loaded, enacts a click on the <code>a.loadMore</code> element, then waits 800 milliseconds before signaling the <code>end()</code>:</p>
+
+Using the `X-Evaluate` custom header (sent as `X-Forward-X-Evaluate`), you can inject your own Javascript code into web pages. Custom Javascript will be executed once the DOM has loaded.
+
+Custom Javascript should be provided as a text string and contained in its own function. You must also include the special functions `start()` and `end()` to indicate the beginning and end of your custom script. Once `end()` fires, the updated document will be processed by your chosen extraction API.
+
+It's recommended that your `end()` function be offset using `setTimeout` (see [JavaScript Timing Events](https://www.w3schools.com/js/js_timing.asp)) in order to accommodate your primary function processing. Additionally, if your custom Javascript requires access to Ajax-delivered content, it may be necessary to offset your entire function using `setTimeout` in order to delay the start of your processing.
+
+The following sample `X-Evaluate` header waits one-half second after the DOM has loaded, enacts a click on the `a.loadMore` element, then waits 800 milliseconds before signaling the `end()`:
 
 
-```text
-
+```js
 function() {
     start();
     setTimeout(function() {
@@ -276,44 +159,22 @@ function() {
         }
     }, 500);
 }
-
 ```
 
+Delivered as a string value as a custom header:
 
-
-<p>Delivered as a string value as a custom header:</p>
-
-
-```text
+```json
 "X-Forward-X-Evaluate": "function() {start();setTimeout(function(){var loadMoreNode=document.querySelector('a.loadMore');if (loadMoreNode != null) {loadMoreNode.click();setTimeout(function(){end();}, 800);} else {end();}},500);}"
 ```
 
+## Posting Content
 
+If your content is not publicly available (e.g., behind a firewall), you can POST markup directly to the Product API endpoint for analysis:
 
-<h3 id="posting">Posting Content</h3>
-<p>If your content is not publicly available (e.g., behind a firewall), you can POST markup directly to the Product API endpoint for analysis:
-</p>
-
-
-```text
-https://api.diffbot.com/v3/video?token=...&amp;url=...
+```plaintext
+https://api.diffbot.com/v3/video?token=...&url=...
 ```
 
+Please note that the `url` argument is still required, and will be used to resolve any relative links contained in the markup.
 
-<p>Please note that the <code>url</code> argument is still required, and will be used to resolve any relative links contained in the markup.</p>
-<p>Provide the content to analyze as your POST body, and specify the <code>Content-Type</code> header as <code>text/html</code>.</p>
-
-</div>
-
-
-</div>
-
-
-</div>
-
-
-
-
-
-
-</div>
+Provide the content to analyze as your POST body, and specify the `Content-Type` header as `text/html`.


### PR DESCRIPTION
Initial cleanup pass of the API docs (`api-*.md`).

Changes:
1. Content markdownified, HTML removed except where infeasible due to non-standard structure (table cells with colspans, etc.) and I also left HTML links in place in cases where the target needs to change and isn't yet available, to make those links easier to find and fix later.
2. For links to existing other docs pages in the new repo, I referenced the markdown files directly. This means we can change URLs without breaking old links, and if files are renamed or go missing we'll get warnings about missing pages so we'll know to fix broken links (if we forget to grep for the filename and fix them proactively).
3. Header levels adjusted from h3 and h4 to h2 and h3, so we get the automatic table of contents in the right column.
4. Broken links repaired and moved from HTTP to HTTPS where relevant.
5. Language info strings applied to code blocks.
6. Fixed some malformed JSON in those code blocks (to be clear, this isn't an artifact of the import - the JSON is malformed on the old docs site as well)
7. Some other small changes for consistency (for example, the Fields description was previously not present on all relevant API pages, and some but not all pages used HRs between sections)

Open questions:
1. What should go on the 'intro' page? We could do basically a table of contents like on [the old API docs site](https://www.diffbot.com/dev/docs/).
2. We use 'admonitions' in a few places - warnings that certain things are in beta (like Custom JavaScript on most APIs) and helpful links to related content (see the Custom API page for example). I've left these as classed divs for now; we could [style them ourselves](https://v2.docusaurus.io/docs/styling-layout) or use a plugin like [remark-admonitions](https://github.com/elviswolcott/remark-admonitions).
3. The old docs use indented rows with a gray line on the left to indicate arrays of subfields (see for example the `posts` field and its children in [this table](https://www.diffbot.com/dev/docs/discussion/#response)). To reduce the HTML and CSS present, this version instead uses a leading ↳ character in those rows to indicate that they are children. Does this work? I wasn't able to find a best practice for this kind of thing.
4. Probably we'll want to modify the sidebar organization/labels as well.
