### PR TITLE
First draft of crawl efficiency explainer.

### DIFF
--- a/docs/explain-how-long-crawl-site.md
+++ b/docs/explain-how-long-crawl-site.md
@@ -23,7 +23,7 @@ Finally, the overall load on Crawlbot is a factor, as our spiders are distribute
 
 The most convenient way to improve performance of Crawlbot is by using [crawling and processing patterns](guides-patterns) (or regular expressions) to specify exactly which sections of a site to crawl and process.
 
-For instance, if you are only interested in a specific subdomain, make sure that your crawl pattern or regular expression limits your crawling to that subdomain.
+For instance, if you are only interested in a specific subdomain, make sure that your crawl pattern or regular expression limits your crawling to that subdomain. See [Improving Crawl Efficiency](explain-improving-crawl-efficiency) for more tips.
 
 In limited cases ignoring a site’s `robots.txt` instruction is possible, but generally only with permission of the site to be crawled.
 

--- a/docs/explain-improving-crawl-efficiency.md
+++ b/docs/explain-improving-crawl-efficiency.md
@@ -1,0 +1,29 @@
+---
+id: explain-improving-crawl-efficiency
+title: Improving Crawl Efficiency
+sidebar_label: Improving Crawl Efficiency
+---
+
+Crawlbot jobs must first crawl pages for links and then process pages by submitting them to a Diffbot Extraction API. (See [The Difference Between Crawling and Processing](explain-crawling-versus-processing) for more on this.) Each crawled page requires that Crawlbot make at least one request to the target website and check the response for links, but if the page is not processed this won't add any data to the job's results. If a Crawlbot job is crawling many more pages than it is processing, the job will run slowly.
+
+Because of this, when using [patterns and regexes](guides-patterns) to narrow the pages crawled or processed by a Crawlbot job it's best to do as much of the narrowing as possible in the *crawling* stage rather than relying on it only in the *processing* stage.
+
+For example, suppose there is a site you'd like to crawl for articles and you are not interested in its other content. You notice the articles have URLs like `https://example.com/2020/01/improving-inefficient-crawls/` so you consider running a crawl with a configuration like the following:
+
+* Seed URL: `https://example.com`
+* Crawl Patterns: *none*
+* Crawl Regex: *none*
+* Processing Patterns: *none*
+* Processing Regex: `https:\/\/example\.com\/\d+\/\d+\/[\w-]+\/`
+
+This would result in processing all the articles and no other pages. However, it would also mean that Crawlbot would crawl the entire site even though it only processes the articles. That's a lot of pages downloaded and crawled just to be thrown away. It's likely that this crawl would end up being very slow.
+
+A better approach is to more strongly constrain the crawling to avoid crawling many pages that will not be processed. Suppose the site's article archive pages have URLs like `https://example.com/articles/`, `https://example.com/articles/page/2/`, `https://example.com/articles/page/3/` and so on. You could then crawl these archive pages and process the articles linked from them and skip crawling the rest of the site, like so:
+
+* Seed URL: `https://example.com/articles/`
+* Crawl Patterns: `https://example.com/articles/page/`
+* Crawl Regex: *none*
+* Processing Patterns: *none*
+* Processing Regex: `https:\/\/example\.com\/\d+\/\d+\/[\w-]+\/`
+
+This way you'd only crawl the article archive pages and process the article pages. There'd be no extra time waiting while the rest of the site is crawled without adding any useful data to your results. This crawl would gather the same results in a much shorter time.

--- a/docs/guides-patterns.md
+++ b/docs/guides-patterns.md
@@ -4,33 +4,59 @@ title: Crawl and Processing Patterns and Regexes
 sidebar_label: Crawl and Processing Patterns and Regexes
 ---
 
-<p>Crawlbot offers many ways to manually narrow or refine the pages crawled or processed by Diffbot APIs.</p>
+Crawlbot offers many ways to manually narrow or refine the pages crawled or processed by Diffbot APIs.
 
 ([Read our overview of crawling vs processing](explain-crawling-versus-processing))
 
-<p><strong>Patterns (“Crawl” and “Processing”)</strong></p>
-<p>Patterns allow you to quickly and easily restrict pages crawled or processed based on simple URL string matches.</p>
-<p>For example, if a web site organizes its pages under categories — e.g., http://www.example.com/sports/heres-a-sports-article.html — I can instruct Crawlbot to only crawl pages within the “sports” category by specifying a crawl pattern of <code>/sports/</code>. (Including the slashes is even more precise and makes sure not to match a “sports” string elsewhere in the URL.)</p>
-<p>I can also use a crawl pattern if I want to limit crawling to a particular subdomain. For instance, on a crawl starting at https://docs.diffbot.com, I can enter a crawl pattern of <code>docs.diffbot.com</code> to keep Crawlbot from following links to http://www.diffbot.com and http://blog.diffbot.com.</p>
-<p>You can enter multiple patterns to match multiple strings. For instance, to crawl both https://docs.diffbot.com and http://blog.diffbot.com (but not http://www.diffbot.com), I would enter a crawl pattern of:</p>
-<pre>docs.diffbot.com
-blog.diffbot.com</pre>
-<p>(In the Crawlbot interface, place each individual pattern on a new line. Via the API, separate patterns with a <code>||</code>.</p>
-<p><strong>Limiting Matches to the Beginning of URLs</strong></p>
-<p>You can use the caret character (<code>^</code>) to limit pattern matches only to the beginning of a URL. For instance, a processing pattern of:</p>
-<pre>^https://docs.diffbot.com</pre>
-<p>…will limit processing only to pages whose URLs begin with https://docs.diffbot.com. This will prevent processing of URLs like http://www.twitter.com/share?tweet=https://docs.diffbot.com.</p>
-<p><strong>Negative-Match Patterns</strong></p>
-<p>Use the exclamation-point to specify a “negative match” if you want to explicitly exclude pages from being crawled or processed. For instance, to process all pages except those containing “sports” in the URL, I would enter a crawl pattern of <code>!sports</code>.</p>
-<p>When entering multiple patterns, negative matches will override other crawl patterns. That is, a URL with a negative match will be fully ignored, even if another (positive) crawl pattern is also a match.</p>
-<p><strong>Regular Expressions (Crawl and Processing Regexes)</strong></p>
+## Patterns ("Crawl" and "Processing")
+
+Patterns allow you to quickly and easily restrict pages crawled or processed based on simple URL string matches.
+
+For example, if a web site organizes its pages under categories — e.g., http://www.example.com/sports/heres-a-sports-article.html — I can instruct Crawlbot to only crawl pages within the "sports" category by specifying a crawl pattern of `/sports/`. (Including the slashes is even more precise and makes sure not to match a "sports" string elsewhere in the URL.)
+
+I can also use a crawl pattern if I want to limit crawling to a particular subdomain. For instance, on a crawl starting at https://docs.diffbot.com, I can enter a crawl pattern of `docs.diffbot.com` to keep Crawlbot from following links to http://www.diffbot.com and http://blog.diffbot.com.
+
+You can enter multiple patterns to match multiple strings. For instance, to crawl both https://docs.diffbot.com and http://blog.diffbot.com (but not http://www.diffbot.com), I would enter a crawl pattern of:
+
+```
+docs.diffbot.com
+blog.diffbot.com
+```
+
+In the Crawlbot interface, place each individual pattern on a new line. Via the API, separate patterns with a `||`.
+
+## Limiting Matches to the Beginning of URLs
+
+You can use the caret character (`^`) to limit pattern matches only to the beginning of a URL. For instance, a processing pattern of:
+
+```
+^https://docs.diffbot.com
+```
+
+...will limit processing only to pages whose URLs begin with https://docs.diffbot.com. This will prevent processing of URLs like http://www.twitter.com/share?tweet=https://docs.diffbot.com.
+
+## Negative-Match Patterns
+
+Use the exclamation-point to specify a "negative match" if you want to explicitly exclude pages from being crawled or processed. For instance, to process all pages except those containing "sports" in the URL, I would enter a crawl pattern of `!sports`.
+
+When entering multiple patterns, negative matches will override other crawl patterns. That is, a URL with a negative match will be fully ignored, even if another (positive) crawl pattern is also a match.
+
+## Regular Expressions (Crawl and Processing Regexes)
 
 ([Which regular expression syntax does Crawlbot use?](explain-regex))
 
-<p>If you want complete control over your crawling or processing URL matches, you can write a regular expression to only crawl or process URLs that contain a match to your expression.</p>
-<p>For example, to only process pages at https://docs.diffbot.com/ under the “/crawlbot” path and containing “regex”, you could enter a processing regex of:</p>
-<p><code>\/crawlbot.*?regex</code></p>
-<p>Note that crawling and processing regular expressions cannot be used simultaneously with crawling/processing patterns. If both are provided, the crawling/processing patterns will be ignored.</p>
-<p><strong>HTML Processing Patterns</strong><br>
-Crawlbot offers one more option for limiting pages processed. If you enter an HTML Processing Pattern, only pages whose HTML source contains the exact string will be processed.</p>
-<p>Note that Crawlbot only examines the raw source, and does not execute Javascript/Ajax at crawl-time.</p>
+If you want complete control over your crawling or processing URL matches, you can write a regular expression to only crawl or process URLs that contain a match to your expression.
+
+For example, to only process pages at https://docs.diffbot.com/ under the "/crawlbot" path and containing "regex", you could enter a processing regex of:
+
+```
+\/crawlbot.*?regex
+```
+
+Note that crawling and processing regular expressions cannot be used simultaneously with crawling/processing patterns. If both are provided, the crawling/processing patterns will be ignored.
+
+## HTML Processing Patterns
+
+Crawlbot offers one more option for limiting pages processed. If you enter an HTML Processing Pattern, only pages whose HTML source contains the exact string will be processed.
+
+Note that Crawlbot only examines the raw source, and does not execute Javascript/Ajax at crawl-time.

--- a/docs/guides-patterns.md
+++ b/docs/guides-patterns.md
@@ -60,3 +60,9 @@ Note that crawling and processing regular expressions cannot be used simultaneou
 Crawlbot offers one more option for limiting pages processed. If you enter an HTML Processing Pattern, only pages whose HTML source contains the exact string will be processed.
 
 Note that Crawlbot only examines the raw source, and does not execute Javascript/Ajax at crawl-time.
+
+## Implications for Crawl Performance
+
+([How long does it take to crawl a site?](explain-how-long-crawl-site))
+
+While there are many factors that will influence how long it takes to crawl a given site, one of the best ways to speed up your crawl is to use crawling and processing patterns or regular expressions to limit Crawlbot just to the pages you are interested in. For more on this, see [Improving Crawl Efficiency](explain-improving-crawl-efficiency).

--- a/website/sidebars.json
+++ b/website/sidebars.json
@@ -152,7 +152,7 @@
             {
                 "type": "subcategory",
                 "label": "Basics",
-                "ids": ["cb-intro-cb", "cb-basics-cb", "tutorials-crawl-video"]
+                "ids": ["cb-intro-cb", "cb-basics-cb", "tutorials-crawl-video", "explain-improving-crawl-efficiency"]
             },
             {
                 "type": "subcategory",


### PR DESCRIPTION
To encourage users to create efficient and performant crawls, we want to have a page suggesting how to ensure that most crawled pages are processed. We want to be able to link to this page in a few places, so far including:

* Notifications sent when a very inefficient crawl (>10,000 crawled pages per processed page) is automatically paused.
* Dashboard warnings for "unhealthy" crawls (>100 crawled pages per processed page is "possibly unhealthy" and >1000 is "unhealthy")