### PR TITLE
Added segment analytics & updated README for install in /website

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,9 +19,8 @@ To build and test the docs locally:
 
 1. Make sure you have yarn installed ([yarnpkg.com](https://yarnpkg.com))
 2. Clone this repo
-3. `cd docs/diffbot; yarn install`
-4. `cd website`
-5. run `yarn start`
+3. `cd docs/website; yarn install`
+4. run `yarn start`
 
 This will open a browser with the local version running in live-reload mode, so you can see your changes as you save your files. Note that menus will not update with this approach, so you need to kill the server with `CTRL+C` and restart with `yarn start` to test menu changes.
 

--- a/website/static/js/app.js
+++ b/website/static/js/app.js
@@ -186,4 +186,11 @@ docReady(function () {
     script.setAttribute('src', 'https://cdn.usefathom.com/3.js');
     script.setAttribute('site', 'OGXCNLPJ');
     document.querySelector('body').appendChild(script);
+
+    // Add Segment
+    !function(){var analytics=window.analytics=window.analytics||[];if(!analytics.initialize)if(analytics.invoked)window.console&&console.error&&console.error("Segment snippet included twice.");else{analytics.invoked=!0;analytics.methods=["trackSubmit","trackClick","trackLink","trackForm","pageview","identify","reset","group","track","ready","alias","debug","page","once","off","on","addSourceMiddleware","addIntegrationMiddleware","setAnonymousId","addDestinationMiddleware"];analytics.factory=function(e){return function(){var t=Array.prototype.slice.call(arguments);t.unshift(e);analytics.push(t);return analytics}};for(var e=0;e<analytics.methods.length;e++){var t=analytics.methods[e];analytics[t]=analytics.factory(t)}analytics.load=function(e,t){var n=document.createElement("script");n.type="text/javascript";n.async=!0;n.src="https://cdn.segment.com/analytics.js/v1/"+e+"/analytics.min.js";var a=document.getElementsByTagName("script")[0];a.parentNode.insertBefore(n,a);analytics._loadOptions=t};analytics.SNIPPET_VERSION="4.1.0";
+    analytics.load("sQoH4GafKS6QYcbQHc4aQVX3grmKkJJM");
+    analytics.page();
+    }}();
+
 })


### PR DESCRIPTION
Adds segment analytics and a simple page tracker.

`yarn install` doesn't install anything in `/docs` since package.json is in `/docs/website`. Once I ran yarn install in /website all is working as expected. Feel free to pocket veto though.