### PR TITLE
Update error-too-many-collections.md

### DIFF
--- a/docs/error-too-many-collections.md
+++ b/docs/error-too-many-collections.md
@@ -10,9 +10,11 @@ If you ever get the “Too Many Collections” error trying to create a [new bul
 
 This is why there is a timeout period after which inactive crawls will be removed – to make room for newer crawls.
 
-If you have the need for more than 1000 active crawljobs, you have two options:
+If you have reached this limit, you may consider these options for lowering your job numbers:
 
-- Upgrade to a Plus or higher plan and we'll remove this limit from your account or
-- Delete some jobs and try again
+- Consolidate one-off jobs with only default settings into a smaller number of jobs
+- Download the results for your finished jobs, and delete them (this can be done programmatically).
+
+These methods are detailed at https://docs.diffbot.com/docs/en/guides-job-limits.
 
 We recommend you keep an eye on your active crawls and delete them as they are no longer needed. If the data has become stale or you have downloaded it, you are encouraged to remove the crawl. Likewise, if you have already downloaded the data but would like to keep the metadata (crawl settings) around, you can download these settings by using the [Crawlbot API](api-crawljob-api). Such a backed up JSON file is enough to restore your crawljob’s settings even after years of inactivity on your account.


### PR DESCRIPTION
Updating document to remove language that we can, in some cases, increase job limits.  Customers will from here on out be made to believe that 1000 is a hard limit, and that they should manage their jobs with this limit in mind.