### PR TITLE
Removing old links and updating bulkjob retention period

### DIFF
--- a/docs/cb-intro-bulk.md
+++ b/docs/cb-intro-bulk.md
@@ -19,7 +19,6 @@ Inactive bulk jobs will be deleted within ten days of completion. This includes 
 ## Bulk Processing Basics
 
 - [Diffbot Regex Syntax](explain-regex)
-- [When is bulk job data deleted?](explain-when-crawl-bulk-data-deleted)
 - [Bulk Processing URL Report](explain-bulk-url-report)
 - [Do Diffbot APIs Follow Redirects?](explain-apis-follow-redirects)
 - [Do Diffbot APIs Execute JavaScript?](explain-apis-javascript-support)

--- a/docs/cb-intro-bulk.md
+++ b/docs/cb-intro-bulk.md
@@ -12,7 +12,7 @@ Note: The Bulk Processor is not a crawler: it does not spider a site for additio
 
 ## Data Retention
 
-Inactive bulk jobs will be deleted within ten days of completion. This includes the extracted data as well as the job meta information (name, settings, etc.).
+Inactive bulk jobs will be deleted within thrity days of completion. This includes the extracted data as well as the job meta information (name, settings, etc.).
 
 “Active” jobs are those that are not in a permanently “paused” state. Currently active jobs will not be deleted or removed from your account. After a job finishes, it will be subject to regular deletion policies.
 

--- a/docs/cb-intro-bulk.md
+++ b/docs/cb-intro-bulk.md
@@ -12,7 +12,7 @@ Note: The Bulk Processor is not a crawler: it does not spider a site for additio
 
 ## Data Retention
 
-Inactive bulk jobs will be deleted within thrity days of completion. This includes the extracted data as well as the job meta information (name, settings, etc.).
+Inactive bulk jobs will be deleted within thirty days of completion. This includes the extracted data as well as the job meta information (name, settings, etc.).
 
 “Active” jobs are those that are not in a permanently “paused” state. Currently active jobs will not be deleted or removed from your account. After a job finishes, it will be subject to regular deletion policies.
 

--- a/docs/cb-intro-bulk.md
+++ b/docs/cb-intro-bulk.md
@@ -12,7 +12,7 @@ Note: The Bulk Processor is not a crawler: it does not spider a site for additio
 
 ## Data Retention
 
-Inactive bulk jobs will be deleted within thirty days of completion. This includes the extracted data as well as the job meta information (name, settings, etc.).
+Inactive bulk jobs will be deleted within ten days of completion. This includes the extracted data as well as the job meta information (name, settings, etc.).
 
 “Active” jobs are those that are not in a permanently “paused” state. Currently active jobs will not be deleted or removed from your account. After a job finishes, it will be subject to regular deletion policies.
 

--- a/docs/cb-intro-cb.md
+++ b/docs/cb-intro-cb.md
@@ -39,7 +39,6 @@ This includes the extracted data as well as the job meta information (name, sett
 - [Crawling vs Processing](explain-crawling-versus-processing)
 - [How does Diffbot handle duplicate pages/content while crawling?](explain-page-deduplication)
 - [How long does it take to crawl a site?](explain-how-long-crawl-site)
-- [When is crawl or bulk job data deleted?](explain-when-crawl-bulk-data-deleted)
 - [Crawlbot URL Report](explain-crawl-url-report)
 - [Do Diffbot APIs Follow Redirects?](explain-apis-follow-redirects)
 - [Do Diffbot APIs Execute JavaScript?](explain-apis-javascript-support)

--- a/docs/index-bulk.md
+++ b/docs/index-bulk.md
@@ -9,5 +9,4 @@ sidebar_label: Bulkjob index
 - [Bulk Processing Tutorial](tutorials-bulk)
 - [Diffbot Regex Syntax](explain-regex)
 - [Are bulk processing URLs returned in the same order as submitted?](explain-bulk-processing-results-ordering)
-- [When is bulk job data deleted?](explain-when-crawl-bulk-data-deleted)
 - [Bulk Processing URL Report](explain-bulk-url-report)

--- a/docs/index-crawlbot.md
+++ b/docs/index-crawlbot.md
@@ -12,7 +12,6 @@ sidebar_label: Crawlbot index
 - [Crawling vs Processing](explain-crawling-versus-processing)
 - [How does Diffbot handle duplicate pages/content while crawling?](explain-page-deduplication)
 - [How long does it take to crawl a site?](explain-how-long-crawl-site)
-- [When is crawl or bulk job data deleted?](explain-when-crawl-bulk-data-deleted)
 - [Crawlbot URL Report](explain-crawl-url-report)
 
 ## Crawlbot debugging


### PR DESCRIPTION
- Removing links to empty page(explain-when-crawl-bulk-data-deleted)
- Updating [bulkjob retention period](https://support.diffbot.com/changelog/enhance-api-updates/)